### PR TITLE
feat(web): add npm package search to demo

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -130,10 +130,13 @@ document.querySelector('npm-search').addEventListener('npm-add', (e) => {
         } catch {
             return; // don't clobber invalid JSON the user is editing
         }
+        if (!pkg || typeof pkg !== 'object' || Array.isArray(pkg)) return;
     } else {
         pkg = { name: 'my-app', dependencies: {} };
     }
-    if (!pkg.dependencies) pkg.dependencies = {};
+    if (!pkg.dependencies || typeof pkg.dependencies !== 'object' || Array.isArray(pkg.dependencies)) {
+        pkg.dependencies = {};
+    }
     pkg.dependencies[name] = version;
     packageJsonInput.value = JSON.stringify(pkg, null, 2);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -119,6 +119,25 @@ async function copyOutput() {
     }
 }
 
+// Handle package added from <npm-search>
+document.querySelector('npm-search').addEventListener('npm-add', (e) => {
+    const { name, version } = e.detail;
+    let pkg;
+    const current = packageJsonInput.value.trim();
+    if (current) {
+        try {
+            pkg = JSON.parse(current);
+        } catch {
+            return; // don't clobber invalid JSON the user is editing
+        }
+    } else {
+        pkg = { name: 'my-app', dependencies: {} };
+    }
+    if (!pkg.dependencies) pkg.dependencies = {};
+    pkg.dependencies[name] = version;
+    packageJsonInput.value = JSON.stringify(pkg, null, 2);
+});
+
 // Event listeners
 generateBtn.addEventListener('click', generateImportMap);
 copyBtn.addEventListener('click', copyOutput);

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,11 @@
     <main>
         <section class="input-section">
             <div class="form-group">
+                <label>Add Package</label>
+                <npm-search></npm-search>
+            </div>
+
+            <div class="form-group">
                 <label for="package-json">package.json</label>
                 <textarea id="package-json" placeholder='{
   "name": "my-app",
@@ -70,6 +75,91 @@
         </p>
     </footer>
 
+    <template id="npm-search-template">
+        <style>
+            :host { display: block; }
+            * { box-sizing: border-box; margin: 0; padding: 0; }
+            .search-row { display: flex; gap: 0.5rem; align-items: start; }
+            .combobox { flex: 1; position: relative; }
+            input[type="text"] {
+                width: 100%;
+                padding: 0.75rem;
+                font-family: var(--font-mono, monospace);
+                font-size: 0.9rem;
+                background: var(--bg-primary, #f5f5f7);
+                border: 1px solid var(--border, #d2d2d7);
+                border-radius: 4px;
+                color: var(--text-primary, #1d1d1f);
+            }
+            input:focus {
+                outline: 2px solid var(--accent, #d63050);
+                outline-offset: 2px;
+                border-color: var(--accent, #d63050);
+            }
+            [role="listbox"] {
+                position: absolute; top: 100%; left: 0; right: 0;
+                max-height: 300px; overflow-y: auto;
+                background: var(--bg-secondary, #fff);
+                border: 1px solid var(--border, #d2d2d7);
+                border-radius: 0 0 4px 4px;
+                list-style: none; z-index: 10;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            }
+            [role="option"] {
+                padding: 0.5rem 0.75rem; cursor: pointer;
+                font-size: 0.85rem;
+                border-bottom: 1px solid var(--border, #d2d2d7);
+            }
+            [role="option"]:last-child { border-bottom: none; }
+            [role="option"]:hover, [role="option"].active {
+                background: var(--bg-tertiary, #e5e5e7);
+            }
+            [role="option"] strong { color: var(--accent, #d63050); }
+            [role="option"] span { color: var(--text-secondary, #6e6e73); font-size: 0.8rem; }
+            [role="option"] small {
+                color: var(--text-secondary, #6e6e73);
+                display: block; margin-top: 0.15rem;
+                white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+            }
+            select, button {
+                padding: 0.75rem;
+                font-family: var(--font-mono, monospace);
+                font-size: 0.9rem;
+                background: var(--bg-primary, #f5f5f7);
+                border: 1px solid var(--border, #d2d2d7);
+                border-radius: 4px;
+                color: var(--text-primary, #1d1d1f);
+            }
+            select { cursor: pointer; min-width: 10ch; }
+            select:focus, button:focus {
+                outline: 2px solid var(--accent, #d63050);
+                outline-offset: 2px;
+                border-color: var(--accent, #d63050);
+            }
+            select:disabled, button:disabled { opacity: 0.6; cursor: not-allowed; }
+            button {
+                font-weight: 600; cursor: pointer;
+                background: var(--accent, #d63050); color: white;
+                border: none; white-space: nowrap;
+                padding: 0.75rem 1.25rem;
+                transition: background 0.2s;
+            }
+            button:hover:not(:disabled) { background: var(--accent-hover, #e94560); }
+        </style>
+        <div class="search-row">
+            <div class="combobox" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="listbox">
+                <input type="text" id="input" placeholder="Search npm packages..."
+                       autocomplete="off" aria-autocomplete="list" aria-controls="listbox">
+                <ul id="listbox" role="listbox" hidden></ul>
+            </div>
+            <select id="version" disabled aria-label="Package version">
+                <option value="">version</option>
+            </select>
+            <button id="add" type="button" disabled>Add</button>
+        </div>
+    </template>
+
+    <script type="module" src="npm-search.js"></script>
     <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -149,7 +149,8 @@
         <div class="search-row">
             <div class="combobox" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="listbox">
                 <input type="text" id="input" placeholder="Search npm packages..."
-                       autocomplete="off" aria-autocomplete="list" aria-controls="listbox">
+                       autocomplete="off" aria-autocomplete="list" aria-controls="listbox"
+                       aria-label="Search npm packages">
                 <ul id="listbox" role="listbox" hidden></ul>
             </div>
             <select id="version" disabled aria-label="Package version">

--- a/web/npm-search.js
+++ b/web/npm-search.js
@@ -1,0 +1,174 @@
+// <npm-search> web component
+// Fires 'npm-add' CustomEvent with { name, version } detail
+
+/** @tagName npm-search */
+class NpmSearch extends HTMLElement {
+  #activeIndex = -1;
+  #selectedPackage = null;
+  #searchController = null;
+  #debounceId = null;
+  #input; #listbox; #version; #addBtn; #combobox;
+
+  static is = 'npm-search'
+  static { customElements.define(this.is, this); }
+
+  constructor() {
+    super();
+    const template = document.getElementById('npm-search-template');
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.append(template.content.cloneNode(true));
+    this.#input = this.shadowRoot.getElementById('input');
+    this.#listbox = this.shadowRoot.getElementById('listbox');
+    this.#version = this.shadowRoot.getElementById('version');
+    this.#addBtn = this.shadowRoot.getElementById('add');
+    this.#combobox = this.shadowRoot.querySelector('[role="combobox"]');
+  }
+
+  connectedCallback() {
+    this.#input.addEventListener('input', () => this.#onInput());
+    this.#input.addEventListener('keydown', e => this.#onKeydown(e));
+    this.#input.addEventListener('blur', () => setTimeout(() => this.#hideListbox(), 200));
+    this.#addBtn.addEventListener('click', () => this.#addPackage());
+    this.#version.addEventListener('keydown', e => { if (e.key === 'Enter') this.#addPackage(); });
+  }
+
+  #onInput() {
+    this.#selectedPackage = null;
+    this.#version.innerHTML = '<option value="">version</option>';
+    this.#version.disabled = true;
+    this.#addBtn.disabled = true;
+
+    clearTimeout(this.#debounceId);
+    const query = this.#input.value.trim();
+    if (query.length < 2) {
+      this.#hideListbox();
+      return;
+    }
+    this.#debounceId = setTimeout(() => this.#search(query), 250);
+  }
+
+  #onKeydown(e) {
+    const options = this.#listbox.querySelectorAll('[role="option"]');
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!this.#listbox.hidden) this.#setActive(this.#activeIndex + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!this.#listbox.hidden) this.#setActive(this.#activeIndex - 1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (this.#activeIndex >= 0 && options[this.#activeIndex])
+          this.#selectPackage(options[this.#activeIndex].dataset.name);
+        break;
+      case 'Escape':
+        this.#hideListbox();
+        break;
+    }
+  }
+
+  async #search(query) {
+    if (this.#searchController) this.#searchController.abort();
+    this.#searchController = new AbortController();
+    try {
+      const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(query)}&size=10`;
+      const res = await fetch(url, { signal: this.#searchController.signal });
+      const data = await res.json();
+      this.#showResults(data.objects.map(o => o.package));
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error('npm search failed:', err);
+    }
+  }
+
+  #showResults(packages) {
+    this.#listbox.innerHTML = '';
+    this.#activeIndex = -1;
+    if (!packages.length) { this.#hideListbox(); return; }
+    for (const [i, pkg] of packages.entries()) {
+      const li = document.createElement('li');
+      li.role = 'option';
+      li.id = `opt-${i}`;
+      li.dataset.name = pkg.name;
+      li.innerHTML = `<strong>${pkg.name}</strong> <span>${pkg.version}</span>`;
+      if (pkg.description) li.innerHTML += `<br><small>${pkg.description}</small>`;
+      li.addEventListener('click', () => this.#selectPackage(pkg.name));
+      this.#listbox.append(li);
+    }
+    this.#listbox.hidden = false;
+    this.#combobox.setAttribute('aria-expanded', 'true');
+  }
+
+  #hideListbox() {
+    this.#listbox.hidden = true;
+    this.#combobox.setAttribute('aria-expanded', 'false');
+    this.#activeIndex = -1;
+    this.#input.removeAttribute('aria-activedescendant');
+  }
+
+  #setActive(index) {
+    const options = this.#listbox.querySelectorAll('[role="option"]');
+    if (!options.length) return;
+    for (const opt of options) opt.classList.remove('active');
+    this.#activeIndex = ((index % options.length) + options.length) % options.length;
+    options[this.#activeIndex].classList.add('active');
+    options[this.#activeIndex].scrollIntoView({ block: 'nearest' });
+    this.#input.setAttribute('aria-activedescendant', options[this.#activeIndex].id);
+  }
+
+  async #selectPackage(name) {
+    this.#selectedPackage = name;
+    this.#input.value = name;
+    this.#hideListbox();
+    this.#version.disabled = true;
+    this.#version.innerHTML = '<option value="">loading...</option>';
+
+    try {
+      const url = `https://registry.npmjs.org/${encodeURIComponent(name)}`;
+      const res = await fetch(url, { headers: { Accept: 'application/vnd.npm.install-v1+json' } });
+      const data = await res.json();
+      const distTags = data['dist-tags'] || {};
+      const versions = Object.keys(data.versions || {}).reverse();
+
+      this.#version.innerHTML = '';
+      const latest = distTags.latest;
+      if (latest) {
+        const opt = document.createElement('option');
+        opt.value = `^${latest}`;
+        opt.textContent = `^${latest} (latest)`;
+        this.#version.append(opt);
+      }
+      for (const v of versions) {
+        if (v === latest) continue;
+        const opt = document.createElement('option');
+        opt.value = v;
+        opt.textContent = v;
+        this.#version.append(opt);
+      }
+      this.#version.disabled = false;
+      this.#addBtn.disabled = false;
+    } catch (err) {
+      console.error('Failed to fetch versions:', err);
+      this.#version.innerHTML = '<option value="">error</option>';
+    }
+  }
+
+  #addPackage() {
+    if (!this.#selectedPackage || this.#version.disabled) return;
+    const version = this.#version.value;
+    if (!version) return;
+
+    this.dispatchEvent(new CustomEvent('npm-add', {
+      bubbles: true,
+      detail: { name: this.#selectedPackage, version }
+    }));
+
+    this.#selectedPackage = null;
+    this.#input.value = '';
+    this.#version.innerHTML = '<option value="">version</option>';
+    this.#version.disabled = true;
+    this.#addBtn.disabled = true;
+  }
+}
+

--- a/web/npm-search.js
+++ b/web/npm-search.js
@@ -39,6 +39,7 @@ class NpmSearch extends HTMLElement {
     this.#addBtn.disabled = true;
 
     clearTimeout(this.#debounceId);
+    this.#searchController?.abort();
     const query = this.#input.value.trim();
     if (query.length < 2) {
       this.#hideListbox();
@@ -76,6 +77,7 @@ class NpmSearch extends HTMLElement {
       const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(query)}&size=10`;
       const res = await fetch(url, { signal: this.#searchController.signal });
       const data = await res.json();
+      if (this.#input.value.trim() !== query) return;
       this.#showResults(data.objects.map(o => o.package));
     } catch (err) {
       if (err.name !== 'AbortError') console.error('npm search failed:', err);
@@ -91,8 +93,17 @@ class NpmSearch extends HTMLElement {
       li.role = 'option';
       li.id = `opt-${i}`;
       li.dataset.name = pkg.name;
-      li.innerHTML = `<strong>${pkg.name}</strong> <span>${pkg.version}</span>`;
-      if (pkg.description) li.innerHTML += `<br><small>${pkg.description}</small>`;
+      const nameEl = document.createElement('strong');
+      nameEl.textContent = pkg.name;
+      const versionEl = document.createElement('span');
+      versionEl.textContent = pkg.version;
+      li.append(nameEl, document.createTextNode(' '), versionEl);
+      if (pkg.description) {
+        li.append(document.createElement('br'));
+        const desc = document.createElement('small');
+        desc.textContent = pkg.description;
+        li.append(desc);
+      }
       li.addEventListener('click', () => this.#selectPackage(pkg.name));
       this.#listbox.append(li);
     }
@@ -128,6 +139,7 @@ class NpmSearch extends HTMLElement {
       const url = `https://registry.npmjs.org/${encodeURIComponent(name)}`;
       const res = await fetch(url, { headers: { Accept: 'application/vnd.npm.install-v1+json' } });
       const data = await res.json();
+      if (this.#selectedPackage !== name) return;
       const distTags = data['dist-tags'] || {};
       const versions = Object.keys(data.versions || {}).reverse();
 
@@ -149,6 +161,7 @@ class NpmSearch extends HTMLElement {
       this.#version.disabled = false;
       this.#addBtn.disabled = false;
     } catch (err) {
+      if (this.#selectedPackage !== name) return;
       console.error('Failed to fetch versions:', err);
       this.#version.innerHTML = '<option value="">error</option>';
     }


### PR DESCRIPTION
## Summary
- Adds an `<npm-search>` web component to the demo page that searches the npm registry for packages
- Selecting a result fetches available versions, defaulting to `^latest`
- Clicking "Add" inserts the dependency into the package.json textarea (scaffolding a basic one if empty)
- Accessible combobox with keyboard navigation (arrows, enter, escape)
- Shadow DOM styles inherit the page's CSS custom properties for light/dark mode support

## Test plan
- [ ] `make wasm-serve`, open http://localhost:8080
- [ ] Type a package name (e.g. "lit") in the search box, verify dropdown appears
- [ ] Select a package, verify version dropdown populates
- [ ] Click Add with an empty textarea, verify a basic package.json is created
- [ ] Click Add with an existing package.json, verify the dependency is appended
- [ ] Test keyboard navigation (arrow keys, enter, escape)
- [ ] Test in both light and dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an npm package search UI with real-time suggestions.
  * Browse and select specific package versions from results.
  * "Add Package" action inserts the chosen dependency into the project configuration textarea.
  * Keyboard navigation and accessibility improvements for the search and list.
  * Version fetch errors show a clear error state and prevent adding until resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->