### PR TITLE
feat(validate): add validate command for import map linting

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -46,8 +46,9 @@ Exits 0 if the import map is valid, 1 if there are violations.`,
 
   # Machine-readable JSON output
   mappa validate importmap.json --format json`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: run,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	RunE:         run,
 }
 
 func init() {
@@ -55,6 +56,11 @@ func init() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	if format != "text" && format != "json" {
+		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", format)
+	}
+
 	var data []byte
 	var err error
 
@@ -78,11 +84,6 @@ func run(cmd *cobra.Command, args []string) error {
 
 	errs := im.Validate()
 
-	format, _ := cmd.Flags().GetString("format")
-	if format != "text" && format != "json" {
-		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", format)
-	}
-
 	if format == "json" {
 		out, err := json.MarshalIndent(errs, "", "  ")
 		if err != nil {
@@ -96,6 +97,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(errs) > 0 {
+		cmd.SilenceErrors = true
 		return fmt.Errorf("import map has %d validation error(s)", len(errs))
 	}
 

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package validate provides the validate command for mappa.
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"bennypowers.dev/mappa/fs"
+	"bennypowers.dev/mappa/importmap"
+)
+
+// Cmd is the validate cobra command that checks import maps for WHATWG spec violations.
+var Cmd = &cobra.Command{
+	Use:   "validate [file]",
+	Short: "Validate an import map for spec violations",
+	Long: `Validate an import map file against the WHATWG import map specification.
+
+Reads an import map from a file argument or stdin, checks for spec violations
+(trailing-slash consistency, URL format, scope key validity), and reports errors.
+Exits 0 if the import map is valid, 1 if there are violations.`,
+	Example: `  # Validate an import map file
+  mappa validate importmap.json
+
+  # Validate from stdin
+  cat importmap.json | mappa validate
+
+  # Machine-readable JSON output
+  mappa validate importmap.json --format json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: run,
+}
+
+func init() {
+	Cmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	var data []byte
+	var err error
+
+	if len(args) == 1 {
+		osfs := fs.NewOSFileSystem()
+		data, err = osfs.ReadFile(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+	} else {
+		data, err = io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return fmt.Errorf("failed to read stdin: %w", err)
+		}
+	}
+
+	im, err := importmap.Parse(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse import map: %w", err)
+	}
+
+	errs := im.Validate()
+
+	format, _ := cmd.Flags().GetString("format")
+	if format != "text" && format != "json" {
+		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", format)
+	}
+
+	if format == "json" {
+		out, err := json.MarshalIndent(errs, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal errors: %w", err)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	} else {
+		for _, e := range errs {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", e)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("import map has %d validation error(s)", len(errs))
+	}
+
+	return nil
+}

--- a/importmap/importmap.go
+++ b/importmap/importmap.go
@@ -28,10 +28,10 @@ import (
 
 // ValidationError describes a spec violation in an import map.
 type ValidationError struct {
-	Key     string
-	Value   string
-	Scope   string // empty for top-level imports
-	Message string
+	Key     string `json:"key,omitempty"`
+	Value   string `json:"value,omitempty"`
+	Scope   string `json:"scope,omitempty"`
+	Message string `json:"message"`
 }
 
 func (e *ValidationError) Error() string {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"bennypowers.dev/mappa/cmd/generate"
 	"bennypowers.dev/mappa/cmd/inject"
 	"bennypowers.dev/mappa/cmd/trace"
+	"bennypowers.dev/mappa/cmd/validate"
 	"bennypowers.dev/mappa/cmd/version"
 )
 
@@ -82,6 +83,7 @@ func init() {
 	rootCmd.AddCommand(generate.Cmd)
 	rootCmd.AddCommand(inject.Cmd)
 	rootCmd.AddCommand(trace.Cmd)
+	rootCmd.AddCommand(validate.Cmd)
 	rootCmd.AddCommand(version.Cmd)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -577,6 +577,7 @@ func TestHelp(t *testing.T) {
 		"mappa",
 		"generate",
 		"trace",
+		"validate",
 		"--package",
 		"--output",
 	}
@@ -822,6 +823,150 @@ func TestInjectJSONFormat(t *testing.T) {
 				t.Fatalf("Failed to parse JSON line: %v\nline: %s", err, line)
 			}
 		}
+	}
+}
+
+func TestValidateValid(t *testing.T) {
+	fixtureFile := filepath.Join("testdata", "validate", "valid", "input.json")
+
+	stdout, stderr, code := runCLI(t, "validate", fixtureFile)
+	if code != 0 {
+		t.Fatalf("Expected exit code 0 for valid import map, got %d\nstderr: %s\nstdout: %s", code, stderr, stdout)
+	}
+}
+
+func TestValidateInvalid(t *testing.T) {
+	fixtureFile := filepath.Join("testdata", "validate", "invalid", "input.json")
+
+	_, stderr, code := runCLI(t, "validate", fixtureFile)
+	if code == 0 {
+		t.Fatal("Expected non-zero exit code for invalid import map")
+	}
+
+	if !strings.Contains(stderr, "Error:") {
+		t.Errorf("Expected validation errors on stderr, got: %s", stderr)
+	}
+
+	if !strings.Contains(stderr, "trailing-slash") {
+		t.Errorf("Expected trailing-slash error, got: %s", stderr)
+	}
+}
+
+func TestValidateStdin(t *testing.T) {
+	binary := filepath.Join(mustGetwd(), "mappa_test")
+	cmd := exec.Command(binary, "validate")
+	cmd.Stdin = strings.NewReader(`{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  }
+}`)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Expected exit code 0 for valid stdin input, got error: %v\nstderr: %s", err, stderrBuf.String())
+	}
+}
+
+func TestValidateStdinInvalid(t *testing.T) {
+	binary := filepath.Join(mustGetwd(), "mappa_test")
+	cmd := exec.Command(binary, "validate")
+	cmd.Stdin = strings.NewReader(`{
+  "imports": {
+    "lit/": "/node_modules/lit"
+  }
+}`)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("Expected non-zero exit code for invalid stdin input")
+	}
+
+	stderr := stderrBuf.String()
+	if !strings.Contains(stderr, "trailing-slash") {
+		t.Errorf("Expected trailing-slash error on stderr, got: %s", stderr)
+	}
+}
+
+func TestValidateFormatJSON(t *testing.T) {
+	fixtureFile := filepath.Join("testdata", "validate", "invalid", "input.json")
+
+	stdout, _, code := runCLI(t, "validate", fixtureFile, "--format", "json")
+	if code == 0 {
+		t.Fatal("Expected non-zero exit code for invalid import map")
+	}
+
+	// stdout should be valid JSON array
+	var errs []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &errs); err != nil {
+		t.Fatalf("Expected valid JSON array on stdout, got error: %v\nstdout: %s", err, stdout)
+	}
+
+	if len(errs) == 0 {
+		t.Fatal("Expected non-empty JSON array of errors")
+	}
+
+	// Each error should have a Message field
+	for i, e := range errs {
+		if e["Message"] == nil {
+			t.Errorf("Error %d missing 'Message' field: %v", i, e)
+		}
+	}
+}
+
+func TestValidateFormatJSONValid(t *testing.T) {
+	fixtureFile := filepath.Join("testdata", "validate", "valid", "input.json")
+
+	stdout, _, code := runCLI(t, "validate", fixtureFile, "--format", "json")
+	if code != 0 {
+		t.Fatalf("Expected exit code 0 for valid import map, got %d", code)
+	}
+
+	// stdout should be valid JSON with empty/null array
+	var errs []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &errs); err != nil {
+		t.Fatalf("Expected valid JSON on stdout, got error: %v\nstdout: %s", err, stdout)
+	}
+
+	if len(errs) != 0 {
+		t.Errorf("Expected empty array for valid import map, got %d errors", len(errs))
+	}
+}
+
+func TestValidateHelp(t *testing.T) {
+	stdout, _, code := runCLI(t, "validate", "--help")
+	if code != 0 {
+		t.Fatalf("Expected exit code 0 for help, got %d", code)
+	}
+
+	expectedStrings := []string{
+		"--format",
+		"Validate",
+		"import map",
+	}
+
+	for _, s := range expectedStrings {
+		if !strings.Contains(stdout, s) {
+			t.Errorf("Expected %q in validate help output", s)
+		}
+	}
+}
+
+func TestValidateMissingFile(t *testing.T) {
+	_, stderr, code := runCLI(t, "validate", "nonexistent.json")
+	if code == 0 {
+		t.Fatal("Expected non-zero exit code for missing file")
+	}
+
+	if !strings.Contains(stderr, "Error") {
+		t.Errorf("Expected error message, got: %s", stderr)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -855,18 +855,19 @@ func TestValidateInvalid(t *testing.T) {
 func TestValidateStdin(t *testing.T) {
 	binary := filepath.Join(mustGetwd(), "mappa_test")
 	cmd := exec.Command(binary, "validate")
-	cmd.Stdin = strings.NewReader(`{
-  "imports": {
-    "lit": "/node_modules/lit/index.js"
-  }
-}`)
+
+	f, err := os.Open(filepath.Join("testdata", "validate", "valid", "input.json"))
+	if err != nil {
+		t.Fatalf("Failed to open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	cmd.Stdin = f
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		t.Fatalf("Expected exit code 0 for valid stdin input, got error: %v\nstderr: %s", err, stderrBuf.String())
 	}
 }
@@ -874,18 +875,19 @@ func TestValidateStdin(t *testing.T) {
 func TestValidateStdinInvalid(t *testing.T) {
 	binary := filepath.Join(mustGetwd(), "mappa_test")
 	cmd := exec.Command(binary, "validate")
-	cmd.Stdin = strings.NewReader(`{
-  "imports": {
-    "lit/": "/node_modules/lit"
-  }
-}`)
+
+	f, err := os.Open(filepath.Join("testdata", "validate", "invalid", "input.json"))
+	if err != nil {
+		t.Fatalf("Failed to open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	cmd.Stdin = f
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	err := cmd.Run()
-	if err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("Expected non-zero exit code for invalid stdin input")
 	}
 
@@ -913,10 +915,9 @@ func TestValidateFormatJSON(t *testing.T) {
 		t.Fatal("Expected non-empty JSON array of errors")
 	}
 
-	// Each error should have a Message field
 	for i, e := range errs {
-		if e["Message"] == nil {
-			t.Errorf("Error %d missing 'Message' field: %v", i, e)
+		if e["message"] == nil {
+			t.Errorf("Error %d missing 'message' field: %v", i, e)
 		}
 	}
 }

--- a/testdata/validate/invalid/input.json
+++ b/testdata/validate/invalid/input.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "lit/": "/node_modules/lit",
+    "bare": "not-a-valid-url",
+    "empty": ""
+  }
+}

--- a/testdata/validate/valid/input.json
+++ b/testdata/validate/valid/input.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "lit/": "/node_modules/lit/",
+    "@scope/pkg": "/node_modules/@scope/pkg/index.js"
+  }
+}


### PR DESCRIPTION
## Summary

- New `mappa validate` command that checks import maps against the WHATWG spec
- Accepts a file argument or reads from stdin
- Reports trailing-slash consistency, URL format, and scope key violations
- Exits 0 if valid, 1 if violations found
- Supports `--format text` (default) and `--format json` for CI

## Test plan

- [x] 8 integration tests covering valid/invalid files, stdin, JSON format, help, missing file
- [x] `make lint` passes
- [x] `make test` passes (324 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `validate` CLI command to check import map files (optional file argument or stdin). Supports `--format/-f` as `text` (errors to stderr) or `json` (structured array to stdout). Exits non‑zero when validation errors are present; includes help text.

* **Tests**
  * Added comprehensive tests and example fixtures covering valid/invalid inputs and both output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->