### PR TITLE
feat(diff): add diff command to compare import maps

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -1,0 +1,176 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package diff provides the diff command for mappa.
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"bennypowers.dev/mappa/fs"
+	"bennypowers.dev/mappa/importmap"
+)
+
+// Cmd is the diff cobra command that compares two import map JSON files.
+var Cmd = &cobra.Command{
+	Use:   "diff <file-a> <file-b>",
+	Short: "Compare two import map JSON files",
+	Long: `Compare two import map JSON files and show differences.
+
+Shows added, removed, and modified entries for both imports and scopes.
+Exits 0 if the maps are identical, 1 if they differ.`,
+	Example: `  # Compare two import maps (colored text output)
+  mappa diff old-importmap.json new-importmap.json
+
+  # JSON output
+  mappa diff old-importmap.json new-importmap.json --format json`,
+	Args: cobra.ExactArgs(2),
+	RunE: run,
+}
+
+func init() {
+	Cmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	osfs := fs.NewOSFileSystem()
+	format, _ := cmd.Flags().GetString("format")
+	if format != "text" && format != "json" {
+		return fmt.Errorf("invalid format %q: must be 'text' or 'json'", format)
+	}
+
+	aData, err := osfs.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", args[0], err)
+	}
+
+	bData, err := osfs.ReadFile(args[1])
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", args[1], err)
+	}
+
+	a, err := importmap.Parse(aData)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", args[0], err)
+	}
+
+	b, err := importmap.Parse(bData)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", args[1], err)
+	}
+
+	d := importmap.Compare(a, b)
+	w := cmd.OutOrStdout()
+
+	if format == "json" {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(d); err != nil {
+			return fmt.Errorf("failed to encode diff: %w", err)
+		}
+	} else {
+		printTextDiff(w, d)
+	}
+
+	if !d.Empty() {
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		return fmt.Errorf("import maps differ")
+	}
+
+	return nil
+}
+
+const (
+	colorRed   = "\033[31m"
+	colorGreen = "\033[32m"
+	colorCyan  = "\033[36m"
+	colorReset = "\033[0m"
+)
+
+func printTextDiff(w io.Writer, d *importmap.Diff) {
+	if d.Empty() {
+		_, _ = fmt.Fprintln(w, "Import maps are identical.")
+		return
+	}
+
+	if !d.Imports.Empty() {
+		_, _ = fmt.Fprintln(w, "imports:")
+		printMapDiff(w, d.Imports, "  ")
+	}
+
+	for _, scope := range d.AddedScopes {
+		_, _ = fmt.Fprintf(w, "%s+ scope %s%s\n", colorGreen, scope, colorReset)
+	}
+
+	for _, scope := range d.RemovedScopes {
+		_, _ = fmt.Fprintf(w, "%s- scope %s%s\n", colorRed, scope, colorReset)
+	}
+
+	scopeKeys := make([]string, 0, len(d.Scopes))
+	for k := range d.Scopes {
+		scopeKeys = append(scopeKeys, k)
+	}
+	sort.Strings(scopeKeys)
+
+	for _, scope := range scopeKeys {
+		sd := d.Scopes[scope]
+		if !sd.Empty() {
+			_, _ = fmt.Fprintf(w, "scope %s:\n", scope)
+			printMapDiff(w, sd, "  ")
+		}
+	}
+}
+
+func printMapDiff(w io.Writer, d importmap.MapDiff, indent string) {
+	keys := sortedKeys(d.Added)
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(w, "%s%s+ %s: %s%s\n", indent, colorGreen, key, d.Added[key], colorReset)
+	}
+
+	keys = sortedKeys(d.Removed)
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(w, "%s%s- %s: %s%s\n", indent, colorRed, key, d.Removed[key], colorReset)
+	}
+
+	modKeys := make([]string, 0, len(d.Modified))
+	for k := range d.Modified {
+		modKeys = append(modKeys, k)
+	}
+	sort.Strings(modKeys)
+
+	for _, key := range modKeys {
+		vals := d.Modified[key]
+		_, _ = fmt.Fprintf(w, "%s%s~ %s:%s\n", indent, colorCyan, key, colorReset)
+		_, _ = fmt.Fprintf(w, "%s  %s- %s%s\n", indent, colorRed, vals[0], colorReset)
+		_, _ = fmt.Fprintf(w, "%s  %s+ %s%s\n", indent, colorGreen, vals[1], colorReset)
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/importmap/diff.go
+++ b/importmap/diff.go
@@ -1,0 +1,166 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package importmap
+
+import "sort"
+
+// MapDiff describes changes between two specifier maps.
+type MapDiff struct {
+	// Added contains entries present in B but not in A.
+	Added map[string]string `json:"added"`
+
+	// Removed contains entries present in A but not in B.
+	Removed map[string]string `json:"removed"`
+
+	// Modified contains entries present in both but with different values.
+	// Each value is [old, new].
+	Modified map[string][2]string `json:"modified"`
+}
+
+// Empty reports whether the diff contains no changes.
+func (d MapDiff) Empty() bool {
+	return len(d.Added) == 0 && len(d.Removed) == 0 && len(d.Modified) == 0
+}
+
+// Diff describes the differences between two import maps.
+type Diff struct {
+	// Imports holds the diff of top-level imports.
+	Imports MapDiff `json:"imports"`
+
+	// Scopes holds per-scope diffs for scopes present in both maps.
+	Scopes map[string]MapDiff `json:"scopes"`
+
+	// AddedScopes lists scope keys present in B but not A.
+	AddedScopes []string `json:"added_scopes"`
+
+	// RemovedScopes lists scope keys present in A but not B.
+	RemovedScopes []string `json:"removed_scopes"`
+}
+
+// Empty reports whether the diff contains no changes.
+func (d *Diff) Empty() bool {
+	if !d.Imports.Empty() {
+		return false
+	}
+	if len(d.AddedScopes) > 0 || len(d.RemovedScopes) > 0 {
+		return false
+	}
+	for _, sd := range d.Scopes {
+		if !sd.Empty() {
+			return false
+		}
+	}
+	return true
+}
+
+// Compare computes the diff between two import maps.
+// A nil import map is treated as empty.
+func Compare(a, b *ImportMap) *Diff {
+	aImports := emptyIfNil(getImports(a))
+	bImports := emptyIfNil(getImports(b))
+	aScopes := emptyIfNilScopes(getScopes(a))
+	bScopes := emptyIfNilScopes(getScopes(b))
+
+	d := &Diff{
+		Imports: diffMaps(aImports, bImports),
+		Scopes:  make(map[string]MapDiff),
+	}
+
+	// Find scopes present in both, added, or removed
+	for scope, bEntries := range bScopes {
+		if aEntries, ok := aScopes[scope]; ok {
+			sd := diffMaps(aEntries, bEntries)
+			if !sd.Empty() {
+				d.Scopes[scope] = sd
+			}
+		} else {
+			d.AddedScopes = append(d.AddedScopes, scope)
+		}
+	}
+	for scope := range aScopes {
+		if _, ok := bScopes[scope]; !ok {
+			d.RemovedScopes = append(d.RemovedScopes, scope)
+		}
+	}
+
+	sort.Strings(d.AddedScopes)
+	sort.Strings(d.RemovedScopes)
+
+	if d.AddedScopes == nil {
+		d.AddedScopes = []string{}
+	}
+	if d.RemovedScopes == nil {
+		d.RemovedScopes = []string{}
+	}
+
+	return d
+}
+
+func getImports(im *ImportMap) map[string]string {
+	if im == nil {
+		return nil
+	}
+	return im.Imports
+}
+
+func getScopes(im *ImportMap) map[string]map[string]string {
+	if im == nil {
+		return nil
+	}
+	return im.Scopes
+}
+
+func emptyIfNil(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+func emptyIfNilScopes(m map[string]map[string]string) map[string]map[string]string {
+	if m == nil {
+		return map[string]map[string]string{}
+	}
+	return m
+}
+
+func diffMaps(a, b map[string]string) MapDiff {
+	d := MapDiff{
+		Added:    make(map[string]string),
+		Removed:  make(map[string]string),
+		Modified: make(map[string][2]string),
+	}
+
+	for key, aVal := range a {
+		if bVal, ok := b[key]; ok {
+			if aVal != bVal {
+				d.Modified[key] = [2]string{aVal, bVal}
+			}
+		} else {
+			d.Removed[key] = aVal
+		}
+	}
+
+	for key, bVal := range b {
+		if _, ok := a[key]; !ok {
+			d.Added[key] = bVal
+		}
+	}
+
+	return d
+}

--- a/importmap/diff_test.go
+++ b/importmap/diff_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package importmap_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"bennypowers.dev/mappa/importmap"
+	"bennypowers.dev/mappa/testutil"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{"identical maps", "diff-identical"},
+		{"added entries", "diff-added"},
+		{"removed entries", "diff-removed"},
+		{"modified entries", "diff-modified"},
+		{"scope changes", "diff-scopes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mfs := testutil.NewFixtureFS(t, "importmap/"+tt.dir, "/test")
+
+			aData, err := mfs.ReadFile("/test/a.json")
+			if err != nil {
+				t.Fatalf("Failed to read a.json: %v", err)
+			}
+
+			bData, err := mfs.ReadFile("/test/b.json")
+			if err != nil {
+				t.Fatalf("Failed to read b.json: %v", err)
+			}
+
+			expectedData, err := mfs.ReadFile("/test/expected.json")
+			if err != nil {
+				t.Fatalf("Failed to read expected.json: %v", err)
+			}
+
+			a, err := importmap.Parse(aData)
+			if err != nil {
+				t.Fatalf("Failed to parse a.json: %v", err)
+			}
+
+			b, err := importmap.Parse(bData)
+			if err != nil {
+				t.Fatalf("Failed to parse b.json: %v", err)
+			}
+
+			result := importmap.Compare(a, b)
+
+			// Marshal result to JSON for comparison
+			resultJSON, err := json.Marshal(result)
+			if err != nil {
+				t.Fatalf("Failed to marshal result: %v", err)
+			}
+
+			// Parse both as generic maps to compare
+			var resultMap, expectedMap map[string]any
+			if err := json.Unmarshal(resultJSON, &resultMap); err != nil {
+				t.Fatalf("Failed to unmarshal result: %v", err)
+			}
+			if err := json.Unmarshal(expectedData, &expectedMap); err != nil {
+				t.Fatalf("Failed to unmarshal expected: %v", err)
+			}
+
+			resultNorm, _ := json.MarshalIndent(resultMap, "", "  ")
+			expectedNorm, _ := json.MarshalIndent(expectedMap, "", "  ")
+
+			if string(resultNorm) != string(expectedNorm) {
+				t.Errorf("Diff mismatch:\n  got:\n%s\n  expected:\n%s", resultNorm, expectedNorm)
+			}
+		})
+	}
+}
+
+func TestCompareNils(t *testing.T) {
+	t.Run("both nil", func(t *testing.T) {
+		result := importmap.Compare(nil, nil)
+		if !result.Empty() {
+			t.Error("Expected empty diff for two nil import maps")
+		}
+	})
+
+	t.Run("a nil", func(t *testing.T) {
+		b := &importmap.ImportMap{
+			Imports: map[string]string{"lit": "/lit.js"},
+		}
+		result := importmap.Compare(nil, b)
+		if result.Empty() {
+			t.Error("Expected non-empty diff when a is nil and b has imports")
+		}
+		if result.Imports.Added["lit"] != "/lit.js" {
+			t.Errorf("Expected lit in added, got %v", result.Imports.Added)
+		}
+	})
+
+	t.Run("b nil", func(t *testing.T) {
+		a := &importmap.ImportMap{
+			Imports: map[string]string{"lit": "/lit.js"},
+		}
+		result := importmap.Compare(a, nil)
+		if result.Empty() {
+			t.Error("Expected non-empty diff when b is nil and a has imports")
+		}
+		if result.Imports.Removed["lit"] != "/lit.js" {
+			t.Errorf("Expected lit in removed, got %v", result.Imports.Removed)
+		}
+	})
+}
+
+func TestMapDiffEmpty(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		d := importmap.MapDiff{
+			Added:    map[string]string{},
+			Removed:  map[string]string{},
+			Modified: map[string][2]string{},
+		}
+		if !d.Empty() {
+			t.Error("Expected empty MapDiff to report Empty()")
+		}
+	})
+
+	t.Run("has added", func(t *testing.T) {
+		d := importmap.MapDiff{
+			Added:    map[string]string{"foo": "bar"},
+			Removed:  map[string]string{},
+			Modified: map[string][2]string{},
+		}
+		if d.Empty() {
+			t.Error("Expected non-empty MapDiff with added entries")
+		}
+	})
+
+	t.Run("has removed", func(t *testing.T) {
+		d := importmap.MapDiff{
+			Added:    map[string]string{},
+			Removed:  map[string]string{"foo": "bar"},
+			Modified: map[string][2]string{},
+		}
+		if d.Empty() {
+			t.Error("Expected non-empty MapDiff with removed entries")
+		}
+	})
+
+	t.Run("has modified", func(t *testing.T) {
+		d := importmap.MapDiff{
+			Added:    map[string]string{},
+			Removed:  map[string]string{},
+			Modified: map[string][2]string{"foo": {"old", "new"}},
+		}
+		if d.Empty() {
+			t.Error("Expected non-empty MapDiff with modified entries")
+		}
+	})
+}
+
+func TestDiffEmpty(t *testing.T) {
+	t.Run("empty diff", func(t *testing.T) {
+		d := &importmap.Diff{
+			Imports: importmap.MapDiff{
+				Added:    map[string]string{},
+				Removed:  map[string]string{},
+				Modified: map[string][2]string{},
+			},
+			Scopes:        map[string]importmap.MapDiff{},
+			AddedScopes:   []string{},
+			RemovedScopes: []string{},
+		}
+		if !d.Empty() {
+			t.Error("Expected empty Diff to report Empty()")
+		}
+	})
+
+	t.Run("has added scopes", func(t *testing.T) {
+		d := &importmap.Diff{
+			Imports: importmap.MapDiff{
+				Added:    map[string]string{},
+				Removed:  map[string]string{},
+				Modified: map[string][2]string{},
+			},
+			Scopes:        map[string]importmap.MapDiff{},
+			AddedScopes:   []string{"/new/"},
+			RemovedScopes: []string{},
+		}
+		if d.Empty() {
+			t.Error("Expected non-empty Diff with added scopes")
+		}
+	})
+
+	t.Run("has scope diff", func(t *testing.T) {
+		d := &importmap.Diff{
+			Imports: importmap.MapDiff{
+				Added:    map[string]string{},
+				Removed:  map[string]string{},
+				Modified: map[string][2]string{},
+			},
+			Scopes: map[string]importmap.MapDiff{
+				"/scope/": {
+					Added:    map[string]string{"foo": "bar"},
+					Removed:  map[string]string{},
+					Modified: map[string][2]string{},
+				},
+			},
+			AddedScopes:   []string{},
+			RemovedScopes: []string{},
+		}
+		if d.Empty() {
+			t.Error("Expected non-empty Diff with scope changes")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"bennypowers.dev/mappa/cmd/diff"
 	"bennypowers.dev/mappa/cmd/generate"
 	"bennypowers.dev/mappa/cmd/inject"
 	"bennypowers.dev/mappa/cmd/trace"
@@ -79,6 +80,7 @@ func init() {
 	_ = viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 
 	// Add commands (alphabetized)
+	rootCmd.AddCommand(diff.Cmd)
 	rootCmd.AddCommand(generate.Cmd)
 	rootCmd.AddCommand(inject.Cmd)
 	rootCmd.AddCommand(trace.Cmd)

--- a/main_test.go
+++ b/main_test.go
@@ -575,6 +575,7 @@ func TestHelp(t *testing.T) {
 
 	expectedStrings := []string{
 		"mappa",
+		"diff",
 		"generate",
 		"trace",
 		"--package",
@@ -822,6 +823,122 @@ func TestInjectJSONFormat(t *testing.T) {
 				t.Fatalf("Failed to parse JSON line: %v\nline: %s", err, line)
 			}
 		}
+	}
+}
+
+func TestDiffHelp(t *testing.T) {
+	stdout, _, code := runCLI(t, "diff", "--help")
+	if code != 0 {
+		t.Fatalf("Expected exit code 0 for help, got %d", code)
+	}
+
+	expectedStrings := []string{
+		"--format",
+		"<file-a>",
+		"<file-b>",
+	}
+
+	for _, s := range expectedStrings {
+		if !strings.Contains(stdout, s) {
+			t.Errorf("Expected %q in diff help output", s)
+		}
+	}
+}
+
+func TestDiffIdentical(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "importmap", "diff-identical")
+	fileA := filepath.Join(fixtureDir, "a.json")
+	fileB := filepath.Join(fixtureDir, "b.json")
+
+	stdout, stderr, code := runCLI(t, "diff", fileA, fileB)
+	if code != 0 {
+		t.Fatalf("Expected exit code 0 for identical maps, got %d\nstderr: %s", code, stderr)
+	}
+
+	if !strings.Contains(stdout, "identical") {
+		t.Errorf("Expected 'identical' in output, got: %s", stdout)
+	}
+}
+
+func TestDiffDifferent(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "importmap", "diff-added")
+	fileA := filepath.Join(fixtureDir, "a.json")
+	fileB := filepath.Join(fixtureDir, "b.json")
+
+	stdout, _, code := runCLI(t, "diff", fileA, fileB)
+	if code != 1 {
+		t.Fatalf("Expected exit code 1 for different maps, got %d", code)
+	}
+
+	if !strings.Contains(stdout, "@lit/reactive-element") {
+		t.Errorf("Expected added entry in output, got: %s", stdout)
+	}
+}
+
+func TestDiffJSONFormat(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "importmap", "diff-modified")
+	fileA := filepath.Join(fixtureDir, "a.json")
+	fileB := filepath.Join(fixtureDir, "b.json")
+
+	stdout, _, code := runCLI(t, "diff", fileA, fileB, "--format", "json")
+	if code != 1 {
+		t.Fatalf("Expected exit code 1 for different maps, got %d", code)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("Expected valid JSON output, got parse error: %v\nstdout: %s", err, stdout)
+	}
+
+	imports, ok := result["imports"].(map[string]any)
+	if !ok {
+		t.Fatal("Expected 'imports' key in JSON output")
+	}
+
+	modified, ok := imports["modified"].(map[string]any)
+	if !ok {
+		t.Fatal("Expected 'modified' key in imports")
+	}
+
+	if modified["@lit/reactive-element"] == nil {
+		t.Error("Expected '@lit/reactive-element' in modified entries")
+	}
+}
+
+func TestDiffMissingArgs(t *testing.T) {
+	_, stderr, code := runCLI(t, "diff")
+	if code == 0 {
+		t.Error("Expected non-zero exit code for missing arguments")
+	}
+
+	if !strings.Contains(stderr, "2 arg(s)") {
+		t.Errorf("Expected arg count error, got: %s", stderr)
+	}
+}
+
+func TestDiffMissingFile(t *testing.T) {
+	_, stderr, code := runCLI(t, "diff", "nonexistent.json", "also-nonexistent.json")
+	if code == 0 {
+		t.Error("Expected non-zero exit code for missing file")
+	}
+
+	if !strings.Contains(stderr, "failed to read") {
+		t.Errorf("Expected 'failed to read' error, got: %s", stderr)
+	}
+}
+
+func TestDiffInvalidFormat(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "importmap", "diff-identical")
+	fileA := filepath.Join(fixtureDir, "a.json")
+	fileB := filepath.Join(fixtureDir, "b.json")
+
+	_, stderr, code := runCLI(t, "diff", fileA, fileB, "--format", "xml")
+	if code == 0 {
+		t.Error("Expected non-zero exit code for invalid format")
+	}
+
+	if !strings.Contains(stderr, "invalid format") {
+		t.Errorf("Expected 'invalid format' error, got: %s", stderr)
 	}
 }
 

--- a/testdata/importmap/diff-added/a.json
+++ b/testdata/importmap/diff-added/a.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  }
+}

--- a/testdata/importmap/diff-added/b.json
+++ b/testdata/importmap/diff-added/b.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "@lit/reactive-element": "/node_modules/@lit/reactive-element/index.js"
+  }
+}

--- a/testdata/importmap/diff-added/expected.json
+++ b/testdata/importmap/diff-added/expected.json
@@ -1,0 +1,12 @@
+{
+  "imports": {
+    "added": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/index.js"
+    },
+    "removed": {},
+    "modified": {}
+  },
+  "scopes": {},
+  "added_scopes": [],
+  "removed_scopes": []
+}

--- a/testdata/importmap/diff-identical/a.json
+++ b/testdata/importmap/diff-identical/a.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "lit/": "/node_modules/lit/"
+  }
+}

--- a/testdata/importmap/diff-identical/b.json
+++ b/testdata/importmap/diff-identical/b.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "lit/": "/node_modules/lit/"
+  }
+}

--- a/testdata/importmap/diff-identical/expected.json
+++ b/testdata/importmap/diff-identical/expected.json
@@ -1,0 +1,10 @@
+{
+  "imports": {
+    "added": {},
+    "removed": {},
+    "modified": {}
+  },
+  "scopes": {},
+  "added_scopes": [],
+  "removed_scopes": []
+}

--- a/testdata/importmap/diff-modified/a.json
+++ b/testdata/importmap/diff-modified/a.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "@lit/reactive-element": "/node_modules/@lit/reactive-element/v1/index.js"
+  }
+}

--- a/testdata/importmap/diff-modified/b.json
+++ b/testdata/importmap/diff-modified/b.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "@lit/reactive-element": "/node_modules/@lit/reactive-element/v2/index.js"
+  }
+}

--- a/testdata/importmap/diff-modified/expected.json
+++ b/testdata/importmap/diff-modified/expected.json
@@ -1,0 +1,15 @@
+{
+  "imports": {
+    "added": {},
+    "removed": {},
+    "modified": {
+      "@lit/reactive-element": [
+        "/node_modules/@lit/reactive-element/v1/index.js",
+        "/node_modules/@lit/reactive-element/v2/index.js"
+      ]
+    }
+  },
+  "scopes": {},
+  "added_scopes": [],
+  "removed_scopes": []
+}

--- a/testdata/importmap/diff-removed/a.json
+++ b/testdata/importmap/diff-removed/a.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "@lit/reactive-element": "/node_modules/@lit/reactive-element/index.js"
+  }
+}

--- a/testdata/importmap/diff-removed/b.json
+++ b/testdata/importmap/diff-removed/b.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  }
+}

--- a/testdata/importmap/diff-removed/expected.json
+++ b/testdata/importmap/diff-removed/expected.json
@@ -1,0 +1,12 @@
+{
+  "imports": {
+    "added": {},
+    "removed": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/index.js"
+    },
+    "modified": {}
+  },
+  "scopes": {},
+  "added_scopes": [],
+  "removed_scopes": []
+}

--- a/testdata/importmap/diff-scopes/a.json
+++ b/testdata/importmap/diff-scopes/a.json
@@ -1,0 +1,13 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/v1/index.js"
+    },
+    "/old-scope/": {
+      "foo": "/old-scope/foo.js"
+    }
+  }
+}

--- a/testdata/importmap/diff-scopes/b.json
+++ b/testdata/importmap/diff-scopes/b.json
@@ -1,0 +1,14 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/v2/index.js",
+      "lit-html": "/node_modules/lit-html/index.js"
+    },
+    "/new-scope/": {
+      "bar": "/new-scope/bar.js"
+    }
+  }
+}

--- a/testdata/importmap/diff-scopes/expected.json
+++ b/testdata/importmap/diff-scopes/expected.json
@@ -1,0 +1,23 @@
+{
+  "imports": {
+    "added": {},
+    "removed": {},
+    "modified": {}
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "added": {
+        "lit-html": "/node_modules/lit-html/index.js"
+      },
+      "removed": {},
+      "modified": {
+        "@lit/reactive-element": [
+          "/node_modules/@lit/reactive-element/v1/index.js",
+          "/node_modules/@lit/reactive-element/v2/index.js"
+        ]
+      }
+    }
+  },
+  "added_scopes": ["/new-scope/"],
+  "removed_scopes": ["/old-scope/"]
+}


### PR DESCRIPTION
## Summary

- New `mappa diff` command that compares two import map JSON files
- Shows added, removed, and modified entries for both imports and scopes
- Exits 0 if identical, 1 if different
- Supports `--format text` (colored, default) and `--format json`
- Core diff logic in `importmap.Compare()` with `Diff`/`MapDiff` types

## Test plan

- [x] Unit tests for diff logic with 5 fixture scenarios (identical, added, removed, modified, scopes)
- [x] 7 integration tests covering help, identical, different, JSON format, missing args/file, invalid format
- [x] `make lint` passes
- [x] `make test` passes (342 tests)