### PR TITLE
feat(generate): add --exclude flag to filter packages

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -48,6 +48,9 @@ By default, generates local /node_modules paths. Use --template for custom paths
   # Include additional packages (e.g., devDependencies)
   mappa generate --include-package fuse.js
 
+  # Exclude packages from the generated map
+  mappa generate --exclude lodash --exclude underscore
+
   # Merge with an existing import map (input map takes precedence)
   mappa generate --input-map manual-imports.json
 
@@ -60,6 +63,7 @@ func init() {
 	Cmd.Flags().StringP("format", "f", "json", "Output format (json, html)")
 	Cmd.Flags().String("input-map", "", "Import map file to merge with generated output")
 	Cmd.Flags().StringArray("include-package", nil, "Additional packages to include (can be repeated)")
+	Cmd.Flags().StringArray("exclude", nil, "Exclude packages from the generated map (can be repeated)")
 	Cmd.Flags().String("template", "", "URL template (default: /node_modules/{package}/{path})")
 	Cmd.Flags().StringSlice("conditions", nil, "Export condition priority (e.g., production,browser,import,default)")
 	Cmd.Flags().IntP("optimize", "O", 1, "Optimization level: 0=none, 1=simplify+dedup (default)")
@@ -68,6 +72,7 @@ func init() {
 	_ = viper.BindPFlag("format", Cmd.Flags().Lookup("format"))
 	_ = viper.BindPFlag("input-map", Cmd.Flags().Lookup("input-map"))
 	_ = viper.BindPFlag("include-package", Cmd.Flags().Lookup("include-package"))
+	_ = viper.BindPFlag("exclude", Cmd.Flags().Lookup("exclude"))
 	_ = viper.BindPFlag("template", Cmd.Flags().Lookup("template"))
 	_ = viper.BindPFlag("conditions", Cmd.Flags().Lookup("conditions"))
 	_ = viper.BindPFlag("optimize", Cmd.Flags().Lookup("optimize"))
@@ -87,8 +92,9 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid format %q: must be 'json' or 'html'", format)
 	}
 
-	// Get additional packages
+	// Get additional packages and exclusions
 	includePackages := viper.GetStringSlice("include-package")
+	excludePackages := viper.GetStringSlice("exclude")
 
 	// Parse input map if provided
 	var inputMap *importmap.ImportMap
@@ -113,6 +119,9 @@ func run(cmd *cobra.Command, args []string) error {
 	resolver := local.New(osfs, nil)
 	if len(includePackages) > 0 {
 		resolver = resolver.WithPackages(includePackages)
+	}
+	if len(excludePackages) > 0 {
+		resolver = resolver.WithExclude(excludePackages)
 	}
 	resolver, err = resolver.WithTemplate(templateArg)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -126,6 +126,38 @@ func TestGenerateLocal(t *testing.T) {
 	}
 }
 
+func TestGenerateExclude(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "resolve", "with-exclude")
+
+	stdout, stderr, code := runCLI(t, "generate", "--package", fixtureDir, "--exclude", "lodash")
+	if code != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nstderr: %s", code, stderr)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nstdout: %s", err, stdout)
+	}
+
+	imports, ok := result["imports"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected imports object, got %T", result["imports"])
+	}
+
+	// lodash should be excluded
+	if imports["lodash"] != nil {
+		t.Error("Expected lodash to be excluded from imports")
+	}
+
+	// Other deps should still be present
+	if imports["lit"] == nil {
+		t.Error("Expected lit import to be present")
+	}
+	if imports["@example/utils"] == nil {
+		t.Error("Expected @example/utils import to be present")
+	}
+}
+
 func TestGenerateHTMLFormat(t *testing.T) {
 	fixtureDir := filepath.Join("testdata", "resolve", "simple-pkg")
 
@@ -598,6 +630,7 @@ func TestGenerateHelp(t *testing.T) {
 		"--template",
 		"--format",
 		"--include-package",
+		"--exclude",
 	}
 
 	for _, s := range expectedStrings {

--- a/resolve/local/local.go
+++ b/resolve/local/local.go
@@ -651,7 +651,15 @@ func (r *Resolver) addTransitiveDependenciesWithGraph(im *importmap.ImportMap, r
 		sem     = make(chan struct{}, 10) // limit to 10 concurrent goroutines
 	)
 
+	excluded := make(map[string]bool, len(r.excludePackages))
+	for _, pkg := range r.excludePackages {
+		excluded[pkg] = true
+	}
+
 	for depName := range rootPkg.Dependencies {
+		if excluded[depName] {
+			continue
+		}
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()

--- a/resolve/local/local.go
+++ b/resolve/local/local.go
@@ -34,6 +34,7 @@ type Resolver struct {
 	fs                 fs.FileSystem
 	logger             resolve.Logger
 	additionalPackages []string
+	excludePackages    []string
 	template           *resolve.Template
 	inputMap           *importmap.ImportMap
 	workspacePackages  []resolve.WorkspacePackage
@@ -60,6 +61,24 @@ func (r *Resolver) WithPackages(packages []string) *Resolver {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: packages,
+		excludePackages:    r.excludePackages,
+		template:           r.template,
+		inputMap:           r.inputMap,
+		workspacePackages:  r.workspacePackages,
+		includeRootExports: r.includeRootExports,
+		cache:              r.cache,
+		conditions:         r.conditions,
+	}
+}
+
+// WithExclude returns a new Resolver that excludes the specified packages
+// from the generated import map.
+func (r *Resolver) WithExclude(packages []string) *Resolver {
+	return &Resolver{
+		fs:                 r.fs,
+		logger:             r.logger,
+		additionalPackages: r.additionalPackages,
+		excludePackages:    packages,
 		template:           r.template,
 		inputMap:           r.inputMap,
 		workspacePackages:  r.workspacePackages,
@@ -79,6 +98,7 @@ func (r *Resolver) WithTemplate(pattern string) (*Resolver, error) {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           tmpl,
 		inputMap:           r.inputMap,
 		workspacePackages:  r.workspacePackages,
@@ -95,6 +115,7 @@ func (r *Resolver) WithInputMap(im *importmap.ImportMap) *Resolver {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           r.template,
 		inputMap:           im,
 		workspacePackages:  r.workspacePackages,
@@ -112,6 +133,7 @@ func (r *Resolver) WithWorkspacePackages(packages []resolve.WorkspacePackage) *R
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           r.template,
 		inputMap:           r.inputMap,
 		workspacePackages:  packages,
@@ -129,6 +151,7 @@ func (r *Resolver) WithIncludeRootExports() *Resolver {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           r.template,
 		inputMap:           r.inputMap,
 		workspacePackages:  r.workspacePackages,
@@ -147,6 +170,7 @@ func (r *Resolver) WithPackageCache(cache packagejson.Cache) *Resolver {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           r.template,
 		inputMap:           r.inputMap,
 		workspacePackages:  r.workspacePackages,
@@ -164,6 +188,7 @@ func (r *Resolver) WithConditions(conditions []string) *Resolver {
 		fs:                 r.fs,
 		logger:             r.logger,
 		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
 		template:           r.template,
 		inputMap:           r.inputMap,
 		workspacePackages:  r.workspacePackages,
@@ -381,6 +406,11 @@ func (r *Resolver) resolveInternal(rootDir string, graph *resolve.DependencyGrap
 		packagesToProcess[pkgName] = true
 	}
 
+	// Remove excluded packages
+	for _, pkg := range r.excludePackages {
+		delete(packagesToProcess, pkg)
+	}
+
 	// Add direct dependencies to imports (parallel)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -480,6 +510,11 @@ func (r *Resolver) resolveWorkspaceInternal(rootDir string, graph *resolve.Depen
 		if !workspaceNames[pkgName] {
 			allDeps[pkgName] = true
 		}
+	}
+
+	// Remove excluded packages
+	for _, pkg := range r.excludePackages {
+		delete(allDeps, pkg)
 	}
 
 	// 3. Add node_modules dependencies (parallel)

--- a/resolve/local/local_test.go
+++ b/resolve/local/local_test.go
@@ -310,6 +310,43 @@ func TestResolverAutoDiscoverWorkspaces(t *testing.T) {
 	}
 }
 
+func TestResolverWithExclude(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "resolve/with-exclude", "/test")
+
+	expectedData, err := mfs.ReadFile("/test/expected.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected.json: %v", err)
+	}
+
+	var expected importmap.ImportMap
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to parse expected.json: %v", err)
+	}
+
+	resolver := local.New(mfs, nil).WithExclude([]string{"lodash"})
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Imports, expected.Imports) {
+		t.Errorf("Imports mismatch:\n  got:      %v\n  expected: %v", result.Imports, expected.Imports)
+	}
+
+	// Verify lodash is excluded
+	if _, ok := result.Imports["lodash"]; ok {
+		t.Error("Expected lodash to be excluded from imports")
+	}
+
+	// Verify other deps are still present
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Expected lit import, got %v", result.Imports["lit"])
+	}
+	if result.Imports["@example/utils"] != "/node_modules/@example/utils/index.js" {
+		t.Errorf("Expected @example/utils import, got %v", result.Imports["@example/utils"])
+	}
+}
+
 func TestResolverExplicitWorkspacesOverrideAutoDiscovery(t *testing.T) {
 	// Use the existing workspace fixture
 	mfs := testutil.NewFixtureFS(t, "workspace", "/test")

--- a/testdata/resolve/with-exclude/expected.json
+++ b/testdata/resolve/with-exclude/expected.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "@example/utils": "/node_modules/@example/utils/index.js"
+  }
+}

--- a/testdata/resolve/with-exclude/node_modules/@example/utils/package.json
+++ b/testdata/resolve/with-exclude/node_modules/@example/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@example/utils",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/testdata/resolve/with-exclude/node_modules/lit/package.json
+++ b/testdata/resolve/with-exclude/node_modules/lit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lit",
+  "version": "3.0.0",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "default": "./index.cjs"
+    }
+  }
+}

--- a/testdata/resolve/with-exclude/node_modules/lodash/package.json
+++ b/testdata/resolve/with-exclude/node_modules/lodash/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lodash",
+  "version": "4.17.21",
+  "main": "lodash.js"
+}

--- a/testdata/resolve/with-exclude/package.json
+++ b/testdata/resolve/with-exclude/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "lit": "^3.0.0",
+    "lodash": "^4.17.0",
+    "@example/utils": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- New `--exclude` flag for `mappa generate` (repeatable, like `--include-package`)
- Filters specified packages from the generated import map
- Applies to direct dependencies only, not transitive deps in scopes
- New `WithExclude()` builder method on the local resolver

## Test plan

- [x] Unit test with fixture (3 deps, 1 excluded)
- [x] Integration test for `mappa generate --exclude`
- [x] `make lint` passes
- [x] `make test` passes (318 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `--exclude` flag for the `mappa generate` command, allowing developers to exclude specific packages from the generated import map. The flag is repeatable, enabling exclusion of multiple packages in a single command.

* **Tests**
  * Added test coverage validating the exclude feature correctly removes specified packages from imports while preserving all other expected dependencies in the generated map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->