### PR TITLE
fix(cdn): exclude packages from CDN resolver including transitive deps

### DIFF
--- a/cdn/cache.go
+++ b/cdn/cache.go
@@ -100,7 +100,7 @@ func (c *PackageCache) Set(pkgName, version string, pkg *packagejson.PackageJSON
 	}
 
 	// Evict oldest if at capacity
-	if len(c.entries) >= c.maxSize {
+	if len(c.entries) == c.maxSize {
 		oldest := c.order[0]
 		c.order = c.order[1:]
 		delete(c.entries, oldest)
@@ -135,16 +135,16 @@ func (c *PackageCache) GetOrLoad(pkgName, version string, loader func() (*packag
 		return entry.pkg, entry.err
 	}
 
-	// Create new entry with loader
-	entry = &cacheEntry{loader: loader}
-	c.entries[key] = entry
-
 	// Evict oldest if at capacity
-	if len(c.entries) >= c.maxSize {
+	if len(c.entries) == c.maxSize {
 		oldest := c.order[0]
 		c.order = c.order[1:]
 		delete(c.entries, oldest)
 	}
+
+	// Create new entry with loader
+	entry = &cacheEntry{loader: loader}
+	c.entries[key] = entry
 	c.order = append(c.order, key)
 	c.mu.Unlock()
 

--- a/cdn/cache.go
+++ b/cdn/cache.go
@@ -33,9 +33,19 @@ type PackageCache struct {
 }
 
 type cacheEntry struct {
-	pkg  *packagejson.PackageJSON
-	once sync.Once
-	err  error
+	pkg    *packagejson.PackageJSON
+	once   sync.Once
+	err    error
+	loader func() (*packagejson.PackageJSON, error)
+}
+
+func (e *cacheEntry) load() {
+	e.once.Do(func() {
+		if e.loader != nil {
+			e.pkg, e.err = e.loader()
+			e.loader = nil
+		}
+	})
 }
 
 // NewPackageCache creates a new package cache with the specified maximum size.
@@ -110,11 +120,9 @@ func (c *PackageCache) GetOrLoad(pkgName, version string, loader func() (*packag
 	entry, ok := c.entries[key]
 	c.mu.RUnlock()
 
-	if ok && entry.pkg != nil {
-		return entry.pkg, nil
-	}
-	if ok && entry.err != nil {
-		return nil, entry.err
+	if ok {
+		entry.load()
+		return entry.pkg, entry.err
 	}
 
 	// Slow path: create entry and load
@@ -123,15 +131,12 @@ func (c *PackageCache) GetOrLoad(pkgName, version string, loader func() (*packag
 	entry, ok = c.entries[key]
 	if ok {
 		c.mu.Unlock()
-		entry.once.Do(func() {})
-		if entry.err != nil {
-			return nil, entry.err
-		}
-		return entry.pkg, nil
+		entry.load()
+		return entry.pkg, entry.err
 	}
 
-	// Create new entry
-	entry = &cacheEntry{}
+	// Create new entry with loader
+	entry = &cacheEntry{loader: loader}
 	c.entries[key] = entry
 
 	// Evict oldest if at capacity
@@ -143,15 +148,8 @@ func (c *PackageCache) GetOrLoad(pkgName, version string, loader func() (*packag
 	c.order = append(c.order, key)
 	c.mu.Unlock()
 
-	// Load outside the lock
-	entry.once.Do(func() {
-		entry.pkg, entry.err = loader()
-	})
-
-	if entry.err != nil {
-		return nil, entry.err
-	}
-	return entry.pkg, nil
+	entry.load()
+	return entry.pkg, entry.err
 }
 
 // Invalidate removes a specific package from the cache.

--- a/npm/src/mappa.ts
+++ b/npm/src/mappa.ts
@@ -11,6 +11,8 @@ export interface GenerateOptions {
   template?: string;
   /** Export conditions to resolve */
   conditions?: string[];
+  /** Packages to exclude from the generated map, including as transitive dependencies */
+  exclude?: string[];
 }
 
 export interface ResolveOptions {

--- a/resolve/cdn/cdn.go
+++ b/resolve/cdn/cdn.go
@@ -21,6 +21,7 @@ package cdn
 import (
 	"context"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 
@@ -40,8 +41,9 @@ type Resolver struct {
 	logger       resolve.Logger
 	conditions   []string
 	includeDev   bool
-	maxDepth     int  // Maximum dependency depth (0 = unlimited)
-	resolveScope bool // Whether to resolve transitive dependencies as scopes
+	excludePackages []string
+	maxDepth        int  // Maximum dependency depth (0 = unlimited)
+	resolveScope    bool // Whether to resolve transitive dependencies as scopes
 }
 
 // New creates a new CDN resolver with default settings.
@@ -61,16 +63,17 @@ func New(fetcher mappacdn.Fetcher) *Resolver {
 func (r *Resolver) WithProvider(provider mappacdn.Provider) *Resolver {
 	tmpl, _ := resolve.ParseTemplate(provider.ModuleTemplate)
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     provider,
-		registry:     r.registry,
-		template:     tmpl,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   r.conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     r.maxDepth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        provider,
+		registry:        r.registry,
+		template:        tmpl,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
@@ -81,64 +84,68 @@ func (r *Resolver) WithTemplate(pattern string) (*Resolver, error) {
 		return nil, err
 	}
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     tmpl,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   r.conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     r.maxDepth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        tmpl,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}, nil
 }
 
 // WithLogger returns a new Resolver with the specified logger.
 func (r *Resolver) WithLogger(logger resolve.Logger) *Resolver {
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     r.template,
-		cache:        r.cache,
-		logger:       logger,
-		conditions:   r.conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     r.maxDepth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
 // WithConditions returns a new Resolver with the specified export conditions.
 func (r *Resolver) WithConditions(conditions []string) *Resolver {
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     r.template,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     r.maxDepth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
 // WithIncludeDev returns a new Resolver that includes devDependencies.
 func (r *Resolver) WithIncludeDev(include bool) *Resolver {
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     r.template,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   r.conditions,
-		includeDev:   include,
-		maxDepth:     r.maxDepth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      include,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
@@ -146,32 +153,52 @@ func (r *Resolver) WithIncludeDev(include bool) *Resolver {
 // 0 means unlimited (default), 1 means direct dependencies only.
 func (r *Resolver) WithMaxDepth(depth int) *Resolver {
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     r.template,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   r.conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     depth,
-		resolveScope: r.resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        depth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
 // WithResolveScope controls whether to generate scopes for transitive dependencies.
 func (r *Resolver) WithResolveScope(resolveScope bool) *Resolver {
 	return &Resolver{
-		fetcher:      r.fetcher,
-		provider:     r.provider,
-		registry:     r.registry,
-		template:     r.template,
-		cache:        r.cache,
-		logger:       r.logger,
-		conditions:   r.conditions,
-		includeDev:   r.includeDev,
-		maxDepth:     r.maxDepth,
-		resolveScope: resolveScope,
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: r.excludePackages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    resolveScope,
+	}
+}
+
+// WithExclude returns a new Resolver that excludes the specified packages
+// from the generated import map, including as transitive dependencies.
+func (r *Resolver) WithExclude(packages []string) *Resolver {
+	return &Resolver{
+		fetcher:         r.fetcher,
+		provider:        r.provider,
+		registry:        r.registry,
+		template:        r.template,
+		cache:           r.cache,
+		logger:          r.logger,
+		conditions:      r.conditions,
+		includeDev:      r.includeDev,
+		excludePackages: packages,
+		maxDepth:        r.maxDepth,
+		resolveScope:    r.resolveScope,
 	}
 }
 
@@ -201,6 +228,10 @@ func (r *Resolver) ResolvePackageJSON(ctx context.Context, pkg *packagejson.Pack
 				deps[name] = version
 			}
 		}
+	}
+
+	for _, pkg := range r.excludePackages {
+		delete(deps, pkg)
 	}
 
 	// Resolve each dependency
@@ -281,6 +312,9 @@ func (r *Resolver) resolvePackage(
 		sem := make(chan struct{}, 10)
 
 		for depName, depVer := range pkg.Dependencies {
+			if slices.Contains(r.excludePackages, depName) {
+				continue
+			}
 			wg.Add(1)
 			go func(name, ver string) {
 				defer wg.Done()

--- a/resolve/cdn/cdn_test.go
+++ b/resolve/cdn/cdn_test.go
@@ -19,6 +19,7 @@ package cdn
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	mappacdn "bennypowers.dev/mappa/cdn"
@@ -302,7 +303,7 @@ func TestResolverWithExclude(t *testing.T) {
 			t.Error("Expected lib-a in imports")
 		}
 		for k := range im.Imports {
-			if k == "lib-b" || k == "lib-b/helpers" {
+			if k == "lib-b" || strings.HasPrefix(k, "lib-b/") {
 				t.Errorf("Expected lib-b excluded from imports, found key %q", k)
 			}
 		}
@@ -324,14 +325,14 @@ func TestResolverWithExclude(t *testing.T) {
 		}
 		// lib-b should not appear in imports
 		for k := range im.Imports {
-			if k == "lib-b" || k == "lib-b/helpers" {
+			if k == "lib-b" || strings.HasPrefix(k, "lib-b/") {
 				t.Errorf("Expected lib-b excluded from imports, found key %q", k)
 			}
 		}
 		// lib-b should not appear in any scope
 		for scopeKey, scope := range im.Scopes {
 			for k := range scope {
-				if k == "lib-b" || k == "lib-b/helpers" {
+				if k == "lib-b" || strings.HasPrefix(k, "lib-b/") {
 					t.Errorf("Expected lib-b excluded from scope %q, found key %q", scopeKey, k)
 				}
 			}

--- a/resolve/cdn/cdn_test.go
+++ b/resolve/cdn/cdn_test.go
@@ -234,6 +234,111 @@ func TestBuildPackageImports(t *testing.T) {
 	}
 }
 
+func TestResolverWithExclude(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+
+	libARegistry := testutil.LoadFixtureFile(t, "lib-a-registry/response.json")
+	libAPackage := testutil.LoadFixtureFile(t, "lib-a-package/package.json")
+	libBRegistry := testutil.LoadFixtureFile(t, "lib-b-registry/response.json")
+	libBPackage := testutil.LoadFixtureFile(t, "lib-b-package/package.json")
+
+	mockFetcher.AddResponse("https://registry.npmjs.org/lib-a", libARegistry)
+	mockFetcher.AddResponse("https://esm.sh/lib-a@1.0.0/package.json", libAPackage)
+	mockFetcher.AddResponse("https://registry.npmjs.org/lib-b", libBRegistry)
+	mockFetcher.AddResponse("https://esm.sh/lib-b@1.0.0/package.json", libBPackage)
+
+	ctx := context.Background()
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{
+			"lib-a": "^1.0.0",
+			"lib-b": "^1.0.0",
+		},
+	}
+
+	t.Run("without exclude both present", func(t *testing.T) {
+		resolver := New(mockFetcher)
+		im, err := resolver.ResolvePackageJSON(ctx, pkg)
+		if err != nil {
+			t.Fatalf("ResolvePackageJSON error: %v", err)
+		}
+		if im.Imports["lib-a"] == "" {
+			t.Error("Expected lib-a in imports")
+		}
+		if im.Imports["lib-b"] == "" {
+			t.Error("Expected lib-b in imports")
+		}
+	})
+
+	t.Run("transitive deps produce scopes", func(t *testing.T) {
+		pkgOnlyA := &packagejson.PackageJSON{
+			Dependencies: map[string]string{
+				"lib-a": "^1.0.0",
+			},
+		}
+		resolver := New(mockFetcher)
+		im, err := resolver.ResolvePackageJSON(ctx, pkgOnlyA)
+		if err != nil {
+			t.Fatalf("ResolvePackageJSON error: %v", err)
+		}
+		found := false
+		for _, scope := range im.Scopes {
+			if _, ok := scope["lib-b"]; ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected lib-b in a scope as transitive dep of lib-a")
+		}
+	})
+
+	t.Run("exclude direct dependency", func(t *testing.T) {
+		resolver := New(mockFetcher).WithExclude([]string{"lib-b"})
+		im, err := resolver.ResolvePackageJSON(ctx, pkg)
+		if err != nil {
+			t.Fatalf("ResolvePackageJSON error: %v", err)
+		}
+		if im.Imports["lib-a"] == "" {
+			t.Error("Expected lib-a in imports")
+		}
+		for k := range im.Imports {
+			if k == "lib-b" || k == "lib-b/helpers" {
+				t.Errorf("Expected lib-b excluded from imports, found key %q", k)
+			}
+		}
+	})
+
+	t.Run("exclude transitive dependency", func(t *testing.T) {
+		pkgOnlyA := &packagejson.PackageJSON{
+			Dependencies: map[string]string{
+				"lib-a": "^1.0.0",
+			},
+		}
+		resolver := New(mockFetcher).WithExclude([]string{"lib-b"})
+		im, err := resolver.ResolvePackageJSON(ctx, pkgOnlyA)
+		if err != nil {
+			t.Fatalf("ResolvePackageJSON error: %v", err)
+		}
+		if im.Imports["lib-a"] == "" {
+			t.Error("Expected lib-a in imports")
+		}
+		// lib-b should not appear in imports
+		for k := range im.Imports {
+			if k == "lib-b" || k == "lib-b/helpers" {
+				t.Errorf("Expected lib-b excluded from imports, found key %q", k)
+			}
+		}
+		// lib-b should not appear in any scope
+		for scopeKey, scope := range im.Scopes {
+			for k := range scope {
+				if k == "lib-b" || k == "lib-b/helpers" {
+					t.Errorf("Expected lib-b excluded from scope %q, found key %q", scopeKey, k)
+				}
+			}
+		}
+	})
+}
+
 func TestBuildPackageImportsMainFallback(t *testing.T) {
 	mockFetcher := NewMockFetcher()
 	resolver := New(mockFetcher)

--- a/resolve/cdn/testdata/lib-a-package/package.json
+++ b/resolve/cdn/testdata/lib-a-package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lib-a",
+  "version": "1.0.0",
+  "exports": {
+    ".": {"import": "./index.js"},
+    "./util": {"import": "./util.js"}
+  },
+  "dependencies": {
+    "lib-b": "^1.0.0"
+  }
+}

--- a/resolve/cdn/testdata/lib-a-registry/response.json
+++ b/resolve/cdn/testdata/lib-a-registry/response.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-a",
+  "dist-tags": {"latest": "1.0.0"},
+  "versions": {"1.0.0": {"version": "1.0.0"}}
+}

--- a/resolve/cdn/testdata/lib-b-package/package.json
+++ b/resolve/cdn/testdata/lib-b-package/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lib-b",
+  "version": "1.0.0",
+  "exports": {
+    ".": {"import": "./index.js"},
+    "./helpers": {"import": "./helpers.js"}
+  }
+}

--- a/resolve/cdn/testdata/lib-b-registry/response.json
+++ b/resolve/cdn/testdata/lib-b-registry/response.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-b",
+  "dist-tags": {"latest": "1.0.0"},
+  "versions": {"1.0.0": {"version": "1.0.0"}}
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -109,6 +109,9 @@ func doGenerate(args []js.Value) (string, error) {
 	if len(opts.conditions) > 0 {
 		resolver = resolver.WithConditions(opts.conditions)
 	}
+	if len(opts.exclude) > 0 {
+		resolver = resolver.WithExclude(opts.exclude)
+	}
 
 	ctx := context.Background()
 	im, err := resolver.ResolvePackageJSON(ctx, pkg)
@@ -195,6 +198,7 @@ type generateOptions struct {
 	cdn        string
 	template   string
 	conditions []string
+	exclude    []string
 }
 
 func parseGenerateOptions(args []js.Value) generateOptions {
@@ -213,6 +217,9 @@ func parseGenerateOptions(args []js.Value) generateOptions {
 	}
 	if v := obj.Get("conditions"); !v.IsUndefined() && !v.IsNull() {
 		opts.conditions = jsStringArray(v)
+	}
+	if v := obj.Get("exclude"); !v.IsUndefined() && !v.IsNull() {
+		opts.exclude = jsStringArray(v)
 	}
 
 	return opts


### PR DESCRIPTION
## Summary

- Add `WithExclude` to CDN resolver, filtering excluded packages from both direct and transitive dependencies
- Fix pre-existing race condition in `PackageCache.GetOrLoad` where fast path read entry fields while `sync.Once` loader was still running
- Wire `exclude` through WASM `generate()` API and update TypeScript `GenerateOptions` type

## Details

The CDN resolver lacked exclude support entirely. When using `generate()` with the `exclude` option, excluded packages still appeared in the output import map as transitive dependencies of non-excluded packages. This broke monorepo workflows where workspace packages should be served locally rather than from CDN.

The race fix stores the loader function in `cacheEntry` so any goroutine's `entry.load()` call uses the correct loader via `sync.Once` synchronization, rather than the old pattern where the fast path could read `entry.pkg` before the loader finished.

Closes #32

## Test plan

- [x] `TestResolverWithExclude/without_exclude_both_present` -- baseline, both packages resolved
- [x] `TestResolverWithExclude/transitive_deps_produce_scopes` -- proves lib-b appears in scopes before exclusion
- [x] `TestResolverWithExclude/exclude_direct_dependency` -- lib-b removed from imports
- [x] `TestResolverWithExclude/exclude_transitive_dependency` -- lib-b removed from imports and scopes when only lib-a is a direct dep
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (331 tests, `-race` enabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package exclusion functionality to dependency resolution, enabling users to specify packages that should be excluded from import maps, including their transitive dependencies.

* **Tests**
  * Added test coverage for package exclusion scenarios, including direct and transitive dependency filtering.

* **Refactor**
  * Optimized internal cache loading architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->