### PR TITLE
fix(cdn): bound goroutine fan-out and add per-request timeout

### DIFF
--- a/resolve/cdn/cdn.go
+++ b/resolve/cdn/cdn.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	mappacdn "bennypowers.dev/mappa/cdn"
 	"bennypowers.dev/mappa/importmap"
@@ -42,8 +43,10 @@ type Resolver struct {
 	conditions   []string
 	includeDev   bool
 	excludePackages []string
-	maxDepth        int  // Maximum dependency depth (0 = unlimited)
-	resolveScope    bool // Whether to resolve transitive dependencies as scopes
+	maxDepth        int           // Maximum dependency depth (0 = unlimited)
+	resolveScope    bool          // Whether to resolve transitive dependencies as scopes
+	requestTimeout  time.Duration // Per-request timeout (0 = no timeout)
+	concurrency     int           // Max concurrent goroutines across all depths
 }
 
 // New creates a new CDN resolver with default settings.
@@ -56,25 +59,17 @@ func New(fetcher mappacdn.Fetcher) *Resolver {
 		template:     tmpl,
 		cache:        mappacdn.NewPackageCache(100),
 		resolveScope: true,
+		concurrency:  10,
 	}
 }
 
 // WithProvider returns a new Resolver using the specified CDN provider.
 func (r *Resolver) WithProvider(provider mappacdn.Provider) *Resolver {
 	tmpl, _ := resolve.ParseTemplate(provider.ModuleTemplate)
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        provider,
-		registry:        r.registry,
-		template:        tmpl,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      r.conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    r.resolveScope,
-	}
+	c := r.clone()
+	c.provider = provider
+	c.template = tmpl
+	return c
 }
 
 // WithTemplate returns a new Resolver using a custom URL template.
@@ -83,110 +78,74 @@ func (r *Resolver) WithTemplate(pattern string) (*Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        tmpl,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      r.conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    r.resolveScope,
-	}, nil
+	c := r.clone()
+	c.template = tmpl
+	return c, nil
 }
 
 // WithLogger returns a new Resolver with the specified logger.
 func (r *Resolver) WithLogger(logger resolve.Logger) *Resolver {
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        r.template,
-		cache:           r.cache,
-		logger:          logger,
-		conditions:      r.conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    r.resolveScope,
-	}
+	c := r.clone()
+	c.logger = logger
+	return c
 }
 
 // WithConditions returns a new Resolver with the specified export conditions.
 func (r *Resolver) WithConditions(conditions []string) *Resolver {
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        r.template,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    r.resolveScope,
-	}
+	c := r.clone()
+	c.conditions = conditions
+	return c
 }
 
 // WithIncludeDev returns a new Resolver that includes devDependencies.
 func (r *Resolver) WithIncludeDev(include bool) *Resolver {
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        r.template,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      r.conditions,
-		includeDev:      include,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    r.resolveScope,
-	}
+	c := r.clone()
+	c.includeDev = include
+	return c
 }
 
 // WithMaxDepth returns a new Resolver with a maximum dependency depth.
 // 0 means unlimited (default), 1 means direct dependencies only.
 func (r *Resolver) WithMaxDepth(depth int) *Resolver {
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        r.template,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      r.conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        depth,
-		resolveScope:    r.resolveScope,
-	}
+	c := r.clone()
+	c.maxDepth = depth
+	return c
 }
 
 // WithResolveScope controls whether to generate scopes for transitive dependencies.
 func (r *Resolver) WithResolveScope(resolveScope bool) *Resolver {
-	return &Resolver{
-		fetcher:         r.fetcher,
-		provider:        r.provider,
-		registry:        r.registry,
-		template:        r.template,
-		cache:           r.cache,
-		logger:          r.logger,
-		conditions:      r.conditions,
-		includeDev:      r.includeDev,
-		excludePackages: r.excludePackages,
-		maxDepth:        r.maxDepth,
-		resolveScope:    resolveScope,
-	}
+	c := r.clone()
+	c.resolveScope = resolveScope
+	return c
 }
 
 // WithExclude returns a new Resolver that excludes the specified packages
 // from the generated import map, including as transitive dependencies.
 func (r *Resolver) WithExclude(packages []string) *Resolver {
+	c := r.clone()
+	c.excludePackages = packages
+	return c
+}
+
+// WithRequestTimeout returns a new Resolver with a per-request timeout.
+// 0 means no timeout (default). Applied to each HTTP fetch and registry call.
+func (r *Resolver) WithRequestTimeout(d time.Duration) *Resolver {
+	c := r.clone()
+	c.requestTimeout = d
+	return c
+}
+
+// WithConcurrency returns a new Resolver with the specified max concurrent goroutines.
+// Shared across all recursion depths to prevent unbounded fan-out.
+func (r *Resolver) WithConcurrency(n int) *Resolver {
+	c := r.clone()
+	if n > 0 {
+		c.concurrency = n
+	}
+	return c
+}
+
+func (r *Resolver) clone() *Resolver {
 	return &Resolver{
 		fetcher:         r.fetcher,
 		provider:        r.provider,
@@ -194,11 +153,13 @@ func (r *Resolver) WithExclude(packages []string) *Resolver {
 		template:        r.template,
 		cache:           r.cache,
 		logger:          r.logger,
-		conditions:      r.conditions,
+		conditions:      slices.Clone(r.conditions),
 		includeDev:      r.includeDev,
-		excludePackages: packages,
+		excludePackages: slices.Clone(r.excludePackages),
 		maxDepth:        r.maxDepth,
 		resolveScope:    r.resolveScope,
+		requestTimeout:  r.requestTimeout,
+		concurrency:     r.concurrency,
 	}
 }
 
@@ -237,17 +198,14 @@ func (r *Resolver) ResolvePackageJSON(ctx context.Context, pkg *packagejson.Pack
 	// Resolve each dependency
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	sem := make(chan struct{}, 10) // Limit concurrency
+	sem := make(chan struct{}, r.concurrency)
 	visited := sync.Map{}
 
 	for name, versionRange := range deps {
 		wg.Add(1)
 		go func(pkgName, verRange string) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			if err := r.resolvePackage(ctx, result, &mu, &visited, pkgName, verRange, 0); err != nil {
+			if err := r.resolvePackage(ctx, result, &mu, &visited, sem, pkgName, verRange, 0); err != nil {
 				if r.logger != nil {
 					r.logger.Warning("Failed to resolve %s@%s: %v", pkgName, verRange, err)
 				}
@@ -265,41 +223,47 @@ func (r *Resolver) ResolvePackageJSON(ctx context.Context, pkg *packagejson.Pack
 }
 
 // resolvePackage resolves a single package and its dependencies.
+// sem is shared across all recursion depths to bound total concurrency.
+// Acquires sem only for HTTP work, releases before spawning children
+// to prevent deadlock when parents hold slots while waiting on children.
 func (r *Resolver) resolvePackage(
 	ctx context.Context,
 	im *importmap.ImportMap,
 	mu *sync.Mutex,
 	visited *sync.Map,
+	sem chan struct{},
 	pkgName, versionRange string,
 	depth int,
 ) error {
-	// Check max depth
 	if r.maxDepth > 0 && depth >= r.maxDepth {
 		return nil
 	}
 
-	// Resolve version
-	version, err := r.registry.ResolveVersion(ctx, pkgName, versionRange)
-	if err != nil {
+	if err := r.acquireSem(ctx, sem); err != nil {
 		return err
 	}
 
-	// Check if already visited at this or higher version
+	version, err := r.resolveVersion(ctx, pkgName, versionRange)
+	if err != nil {
+		<-sem
+		return err
+	}
+
 	cacheKey := pkgName + "@" + version
 	if _, loaded := visited.LoadOrStore(cacheKey, true); loaded {
+		<-sem
 		return nil
 	}
 
-	// Fetch package.json from CDN
 	pkg, err := r.fetchPackageJSON(ctx, pkgName, version)
+	// Release sem -- HTTP work done, recursive work doesn't need it
+	<-sem
 	if err != nil {
 		return err
 	}
 
-	// Add to imports
 	r.addPackageImports(im, mu, pkgName, version, pkg)
 
-	// Resolve transitive dependencies if enabled
 	if r.resolveScope && (r.maxDepth == 0 || depth < r.maxDepth) && len(pkg.Dependencies) > 0 {
 		scopeKey := r.template.Expand(pkgName, version, "")
 		if !strings.HasSuffix(scopeKey, "/") {
@@ -309,7 +273,6 @@ func (r *Resolver) resolvePackage(
 		scopeEntries := make(map[string]string)
 		var wg sync.WaitGroup
 		var scopeMu sync.Mutex
-		sem := make(chan struct{}, 10)
 
 		for depName, depVer := range pkg.Dependencies {
 			if slices.Contains(r.excludePackages, depName) {
@@ -318,20 +281,22 @@ func (r *Resolver) resolvePackage(
 			wg.Add(1)
 			go func(name, ver string) {
 				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
 
-				// Resolve transitive dependency version
-				resolvedVer, err := r.registry.ResolveVersion(ctx, name, ver)
+				if err := r.acquireSem(ctx, sem); err != nil {
+					return
+				}
+
+				resolvedVer, err := r.resolveVersion(ctx, name, ver)
 				if err != nil {
+					<-sem
 					if r.logger != nil {
 						r.logger.Warning("Failed to resolve transitive dep %s@%s: %v", name, ver, err)
 					}
 					return
 				}
 
-				// Fetch package.json
 				depPkg, err := r.fetchPackageJSON(ctx, name, resolvedVer)
+				<-sem
 				if err != nil {
 					if r.logger != nil {
 						r.logger.Warning("Failed to fetch %s@%s: %v", name, resolvedVer, err)
@@ -339,14 +304,12 @@ func (r *Resolver) resolvePackage(
 					return
 				}
 
-				// Build scope entries
 				entries := r.buildPackageImports(name, resolvedVer, depPkg)
 				scopeMu.Lock()
 				maps.Copy(scopeEntries, entries)
 				scopeMu.Unlock()
 
-				// Recursively resolve deeper dependencies using resolved version
-				if err := r.resolvePackage(ctx, im, mu, visited, name, resolvedVer, depth+1); err != nil {
+				if err := r.resolvePackage(ctx, im, mu, visited, sem, name, resolvedVer, depth+1); err != nil {
 					if r.logger != nil {
 						r.logger.Warning("Failed to resolve transitive dep %s: %v", name, err)
 					}
@@ -371,16 +334,44 @@ func (r *Resolver) resolvePackage(
 	return nil
 }
 
+// acquireSem blocks until a semaphore slot is available or the context is cancelled.
+func (r *Resolver) acquireSem(ctx context.Context, sem chan struct{}) error {
+	select {
+	case sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// resolveVersion wraps registry.ResolveVersion with an optional per-request timeout.
+func (r *Resolver) resolveVersion(ctx context.Context, pkgName, versionRange string) (string, error) {
+	reqCtx, cancel := r.withTimeout(ctx)
+	defer cancel()
+	return r.registry.ResolveVersion(reqCtx, pkgName, versionRange)
+}
+
 // fetchPackageJSON fetches and parses a package.json from the CDN.
 func (r *Resolver) fetchPackageJSON(ctx context.Context, pkgName, version string) (*packagejson.PackageJSON, error) {
 	return r.cache.GetOrLoad(pkgName, version, func() (*packagejson.PackageJSON, error) {
 		url := r.buildPackageJSONURL(pkgName, version)
-		data, err := r.fetcher.Fetch(ctx, url)
+		reqCtx, cancel := r.withTimeout(ctx)
+		defer cancel()
+		data, err := r.fetcher.Fetch(reqCtx, url)
 		if err != nil {
 			return nil, err
 		}
 		return packagejson.Parse(data)
 	})
+}
+
+// withTimeout derives a context with the configured request timeout.
+// Returns the original context and a no-op cancel if no timeout is set.
+func (r *Resolver) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if r.requestTimeout > 0 {
+		return context.WithTimeout(ctx, r.requestTimeout)
+	}
+	return ctx, func() {}
 }
 
 // buildPackageJSONURL builds the URL for a package.json file.

--- a/resolve/cdn/cdn_test.go
+++ b/resolve/cdn/cdn_test.go
@@ -20,7 +20,9 @@ package cdn
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	mappacdn "bennypowers.dev/mappa/cdn"
 	"bennypowers.dev/mappa/packagejson"
@@ -29,14 +31,19 @@ import (
 
 // MockFetcher is a test implementation of the Fetcher interface.
 type MockFetcher struct {
-	responses map[string][]byte
-	errors    map[string]error
+	responses    map[string][]byte
+	errors       map[string]error
+	delays       map[string]time.Duration
+	fetchCount   atomic.Int64
+	maxConcurrent atomic.Int64
+	inflight      atomic.Int64
 }
 
 func NewMockFetcher() *MockFetcher {
 	return &MockFetcher{
 		responses: make(map[string][]byte),
 		errors:    make(map[string]error),
+		delays:    make(map[string]time.Duration),
 	}
 }
 
@@ -48,7 +55,32 @@ func (m *MockFetcher) AddError(url string, err error) {
 	m.errors[url] = err
 }
 
+func (m *MockFetcher) AddDelay(url string, d time.Duration) {
+	m.delays[url] = d
+}
+
 func (m *MockFetcher) Fetch(ctx context.Context, url string) ([]byte, error) {
+	m.fetchCount.Add(1)
+	cur := m.inflight.Add(1)
+	defer m.inflight.Add(-1)
+	for {
+		old := m.maxConcurrent.Load()
+		if cur <= old || m.maxConcurrent.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+
+	if d, ok := m.delays[url]; ok {
+		select {
+		case <-time.After(d):
+		case <-ctx.Done():
+			return nil, &mappacdn.FetchError{URL: url, Message: ctx.Err().Error()}
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, &mappacdn.FetchError{URL: url, Message: err.Error()}
+	}
 	if err, ok := m.errors[url]; ok {
 		return nil, err
 	}
@@ -354,5 +386,196 @@ func TestBuildPackageImportsMainFallback(t *testing.T) {
 
 	if imports["legacy"] != "https://esm.sh/legacy@1.0.0/lib/main.js" {
 		t.Errorf("Unexpected main fallback: %s", imports["legacy"])
+	}
+}
+
+func TestSharedSemaphoreBoundsConcurrency(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+
+	rootRegistry := testutil.LoadFixtureFile(t, "root-registry/response.json")
+	rootPkg := testutil.LoadFixtureFile(t, "root-package/package.json")
+	mockFetcher.AddResponse("https://registry.npmjs.org/root", rootRegistry)
+	mockFetcher.AddResponse("https://esm.sh/root@1.0.0/package.json", rootPkg)
+
+	for _, name := range []string{"dep-a", "dep-b", "dep-c"} {
+		reg := testutil.LoadFixtureFile(t, name+"-registry/response.json")
+		pkg := testutil.LoadFixtureFile(t, name+"-package/package.json")
+		mockFetcher.AddResponse("https://registry.npmjs.org/"+name, reg)
+		mockFetcher.AddResponse("https://esm.sh/"+name+"@1.0.0/package.json", pkg)
+		mockFetcher.AddDelay("https://registry.npmjs.org/"+name, 10*time.Millisecond)
+		mockFetcher.AddDelay("https://esm.sh/"+name+"@1.0.0/package.json", 10*time.Millisecond)
+	}
+
+	resolver := New(mockFetcher).WithConcurrency(2)
+	ctx := context.Background()
+
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{"root": "^1.0.0"},
+	}
+
+	im, err := resolver.ResolvePackageJSON(ctx, pkg)
+	if err != nil {
+		t.Fatalf("ResolvePackageJSON error: %v", err)
+	}
+
+	if im.Imports["root"] == "" {
+		t.Error("Expected 'root' in imports")
+	}
+
+	if max := mockFetcher.maxConcurrent.Load(); max > 2 {
+		t.Errorf("Expected max concurrent <= 2, got %d", max)
+	}
+}
+
+func TestSharedSemaphoreNoDeadlockMultiDepth(t *testing.T) {
+	// Regression test: with per-level semaphores, concurrency=2 with 2 direct
+	// deps each having transitive deps would deadlock. Both parents hold slots
+	// while children wait for slots.
+	// Tree: deep-a -> subdep-a1, deep-b -> subdep-b1
+	mockFetcher := NewMockFetcher()
+
+	for _, name := range []string{"deep-a", "deep-b", "subdep-a1", "subdep-b1"} {
+		reg := testutil.LoadFixtureFile(t, name+"-registry/response.json")
+		pkg := testutil.LoadFixtureFile(t, name+"-package/package.json")
+		mockFetcher.AddResponse("https://registry.npmjs.org/"+name, reg)
+		mockFetcher.AddResponse("https://esm.sh/"+name+"@1.0.0/package.json", pkg)
+		mockFetcher.AddDelay("https://registry.npmjs.org/"+name, 5*time.Millisecond)
+		mockFetcher.AddDelay("https://esm.sh/"+name+"@1.0.0/package.json", 5*time.Millisecond)
+	}
+
+	resolver := New(mockFetcher).WithConcurrency(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{
+			"deep-a": "^1.0.0",
+			"deep-b": "^1.0.0",
+		},
+	}
+
+	im, err := resolver.ResolvePackageJSON(ctx, pkg)
+	if err != nil {
+		t.Fatalf("ResolvePackageJSON error (possible deadlock): %v", err)
+	}
+
+	if im.Imports["deep-a"] == "" {
+		t.Error("Expected 'deep-a' in imports")
+	}
+	if im.Imports["deep-b"] == "" {
+		t.Error("Expected 'deep-b' in imports")
+	}
+}
+
+func TestRequestTimeoutCancelsSlowFetch(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+
+	slowRegistry := testutil.LoadFixtureFile(t, "slow-pkg-registry/response.json")
+	slowPkg := testutil.LoadFixtureFile(t, "slow-pkg-package/package.json")
+	mockFetcher.AddResponse("https://registry.npmjs.org/slow-pkg", slowRegistry)
+	mockFetcher.AddResponse("https://esm.sh/slow-pkg@1.0.0/package.json", slowPkg)
+	mockFetcher.AddDelay("https://esm.sh/slow-pkg@1.0.0/package.json", 500*time.Millisecond)
+
+	resolver := New(mockFetcher).
+		WithRequestTimeout(50 * time.Millisecond).
+		WithMaxDepth(1)
+
+	ctx := context.Background()
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{"slow-pkg": "^1.0.0"},
+	}
+
+	im, err := resolver.ResolvePackageJSON(ctx, pkg)
+	if err != nil {
+		t.Fatalf("ResolvePackageJSON error: %v", err)
+	}
+
+	if im.Imports["slow-pkg"] != "" {
+		t.Error("Expected slow-pkg to be missing from imports due to timeout")
+	}
+}
+
+func TestRequestTimeoutDefaultIsNoTimeout(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+
+	litRegistry := testutil.LoadFixtureFile(t, "lit-registry/response.json")
+	litPackage := testutil.LoadFixtureFile(t, "lit-package/package.json")
+
+	mockFetcher.AddResponse("https://registry.npmjs.org/lit", litRegistry)
+	mockFetcher.AddResponse("https://esm.sh/lit@3.0.0/package.json", litPackage)
+
+	resolver := New(mockFetcher).WithMaxDepth(1)
+	ctx := context.Background()
+
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{"lit": "^3.0.0"},
+	}
+
+	im, err := resolver.ResolvePackageJSON(ctx, pkg)
+	if err != nil {
+		t.Fatalf("ResolvePackageJSON error: %v", err)
+	}
+
+	if im.Imports["lit"] == "" {
+		t.Error("Expected 'lit' in imports")
+	}
+}
+
+func TestContextCancellationStopsSemAcquisition(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+
+	for _, name := range []string{"dep-a", "dep-b", "dep-c"} {
+		reg := testutil.LoadFixtureFile(t, name+"-registry/response.json")
+		pkg := testutil.LoadFixtureFile(t, name+"-package/package.json")
+		mockFetcher.AddResponse("https://registry.npmjs.org/"+name, reg)
+		mockFetcher.AddResponse("https://esm.sh/"+name+"@1.0.0/package.json", pkg)
+		mockFetcher.AddDelay("https://registry.npmjs.org/"+name, 100*time.Millisecond)
+	}
+
+	resolver := New(mockFetcher).WithConcurrency(1).WithMaxDepth(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	pkg := &packagejson.PackageJSON{
+		Dependencies: map[string]string{
+			"dep-a": "^1.0.0",
+			"dep-b": "^1.0.0",
+			"dep-c": "^1.0.0",
+		},
+	}
+
+	im, err := resolver.ResolvePackageJSON(ctx, pkg)
+	if err != nil {
+		t.Fatalf("ResolvePackageJSON error: %v", err)
+	}
+
+	// With concurrency=1 and 100ms delay per dep, 50ms timeout should prevent
+	// resolving all 3 deps
+	resolved := 0
+	for _, name := range []string{"dep-a", "dep-b", "dep-c"} {
+		if im.Imports[name] != "" {
+			resolved++
+		}
+	}
+	if resolved == 3 {
+		t.Error("Expected context cancellation to prevent resolving all deps")
+	}
+}
+
+func TestWithConcurrencyDefault(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+	resolver := New(mockFetcher)
+	if resolver.concurrency != 10 {
+		t.Errorf("Expected default concurrency 10, got %d", resolver.concurrency)
+	}
+}
+
+func TestWithConcurrencyIgnoresZero(t *testing.T) {
+	mockFetcher := NewMockFetcher()
+	resolver := New(mockFetcher).WithConcurrency(0)
+	if resolver.concurrency != 10 {
+		t.Errorf("Expected concurrency to remain 10 for zero input, got %d", resolver.concurrency)
 	}
 }

--- a/resolve/cdn/testdata/deep-a-package/package.json
+++ b/resolve/cdn/testdata/deep-a-package/package.json
@@ -1,0 +1,1 @@
+{"name":"deep-a","version":"1.0.0","exports":{".":"./index.js"},"dependencies":{"subdep-a1":"^1.0.0"}}

--- a/resolve/cdn/testdata/deep-a-registry/response.json
+++ b/resolve/cdn/testdata/deep-a-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"deep-a","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/deep-b-package/package.json
+++ b/resolve/cdn/testdata/deep-b-package/package.json
@@ -1,0 +1,1 @@
+{"name":"deep-b","version":"1.0.0","exports":{".":"./index.js"},"dependencies":{"subdep-b1":"^1.0.0"}}

--- a/resolve/cdn/testdata/deep-b-registry/response.json
+++ b/resolve/cdn/testdata/deep-b-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"deep-b","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/dep-a-package/package.json
+++ b/resolve/cdn/testdata/dep-a-package/package.json
@@ -1,0 +1,1 @@
+{"name":"dep-a","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/dep-a-registry/response.json
+++ b/resolve/cdn/testdata/dep-a-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"dep-a","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/dep-b-package/package.json
+++ b/resolve/cdn/testdata/dep-b-package/package.json
@@ -1,0 +1,1 @@
+{"name":"dep-b","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/dep-b-registry/response.json
+++ b/resolve/cdn/testdata/dep-b-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"dep-b","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/dep-c-package/package.json
+++ b/resolve/cdn/testdata/dep-c-package/package.json
@@ -1,0 +1,1 @@
+{"name":"dep-c","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/dep-c-registry/response.json
+++ b/resolve/cdn/testdata/dep-c-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"dep-c","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/root-package/package.json
+++ b/resolve/cdn/testdata/root-package/package.json
@@ -1,0 +1,1 @@
+{"name":"root","version":"1.0.0","exports":{".":"./index.js"},"dependencies":{"dep-a":"^1.0.0","dep-b":"^1.0.0","dep-c":"^1.0.0"}}

--- a/resolve/cdn/testdata/root-registry/response.json
+++ b/resolve/cdn/testdata/root-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"root","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/slow-pkg-package/package.json
+++ b/resolve/cdn/testdata/slow-pkg-package/package.json
@@ -1,0 +1,1 @@
+{"name":"slow-pkg","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/slow-pkg-registry/response.json
+++ b/resolve/cdn/testdata/slow-pkg-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"slow-pkg","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/subdep-a1-package/package.json
+++ b/resolve/cdn/testdata/subdep-a1-package/package.json
@@ -1,0 +1,1 @@
+{"name":"subdep-a1","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/subdep-a1-registry/response.json
+++ b/resolve/cdn/testdata/subdep-a1-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"subdep-a1","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}

--- a/resolve/cdn/testdata/subdep-b1-package/package.json
+++ b/resolve/cdn/testdata/subdep-b1-package/package.json
@@ -1,0 +1,1 @@
+{"name":"subdep-b1","version":"1.0.0","exports":{".":"./index.js"}}

--- a/resolve/cdn/testdata/subdep-b1-registry/response.json
+++ b/resolve/cdn/testdata/subdep-b1-registry/response.json
@@ -1,0 +1,1 @@
+{"name":"subdep-b1","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"version":"1.0.0"}}}


### PR DESCRIPTION
## Summary

- Share a single semaphore across all recursion depths in CDN resolver, preventing 10^depth goroutine explosion with deep npm dependency trees
- Release semaphore after HTTP work but before spawning children, preventing deadlock when all slots are held by parents waiting on children
- Add `WithRequestTimeout` for per-request context deadlines on registry and CDN fetch calls
- Add `WithConcurrency` to configure the shared goroutine limit (default 10)
- Use `select` on semaphore acquisition to respect context cancellation
- Extract `clone()` method to eliminate field-list duplication across 8 `With*` builders, with `slices.Clone` for slice fields

Closes #34, closes #35

## Test plan

- [x] `TestSharedSemaphoreBoundsConcurrency` -- verifies max concurrent goroutines stay within configured limit
- [x] `TestSharedSemaphoreNoDeadlockMultiDepth` -- regression test with concurrency=2 and multi-level transitive deps (would deadlock with old per-level semaphore)
- [x] `TestRequestTimeoutCancelsSlowFetch` -- verifies slow CDN fetch is cancelled by timeout
- [x] `TestRequestTimeoutDefaultIsNoTimeout` -- verifies default (no timeout) works correctly
- [x] `TestContextCancellationStopsSemAcquisition` -- verifies goroutines respect context cancellation while waiting for semaphore slots
- [x] `TestWithConcurrencyDefault` and `TestWithConcurrencyIgnoresZero` -- builder defaults
- [x] All 338 tests pass, zero lint issues (`make lint && make test`)