### PR TITLE
feat: support workspace subdirectory resolution with WithPathBase and WithPackageDeps

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -68,6 +68,8 @@ func init() {
 	Cmd.Flags().StringSlice("conditions", nil, "Export condition priority (e.g., production,browser,import,default)")
 	Cmd.Flags().IntP("optimize", "O", 1, "Optimization level: 0=none, 1=simplify+dedup (default)")
 	Cmd.Flags().Bool("strict", false, "Exit non-zero on import map validation warnings")
+	Cmd.Flags().String("path-base", "", "Rebase workspace paths relative to this directory")
+	Cmd.Flags().String("package-deps", "", "Limit dependency resolution to this package's dependencies")
 
 	_ = viper.BindPFlag("format", Cmd.Flags().Lookup("format"))
 	_ = viper.BindPFlag("input-map", Cmd.Flags().Lookup("input-map"))
@@ -77,6 +79,8 @@ func init() {
 	_ = viper.BindPFlag("conditions", Cmd.Flags().Lookup("conditions"))
 	_ = viper.BindPFlag("optimize", Cmd.Flags().Lookup("optimize"))
 	_ = viper.BindPFlag("strict", Cmd.Flags().Lookup("strict"))
+	_ = viper.BindPFlag("path-base", Cmd.Flags().Lookup("path-base"))
+	_ = viper.BindPFlag("package-deps", Cmd.Flags().Lookup("package-deps"))
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -116,6 +120,8 @@ func run(cmd *cobra.Command, args []string) error {
 		IncludePackages: viper.GetStringSlice("include-package"),
 		Exclude:         viper.GetStringSlice("exclude"),
 		InputMap:        inputMap,
+		PathBase:         viper.GetString("path-base"),
+		PackageDeps:     viper.GetString("package-deps"),
 	}
 
 	resolver, err := opts.Apply(local.New(osfs, nil))

--- a/npm/src/mappa.ts
+++ b/npm/src/mappa.ts
@@ -28,6 +28,10 @@ export interface ResolveOptions {
   inputMap?: ImportMap;
   /** Optimization level: 0=none, 1=simplify+dedup (default: 1) */
   optimize?: 0 | 1;
+  /** Rebase workspace paths relative to this directory (node_modules paths unaffected) */
+  pathBase?: string;
+  /** Limit dependency resolution to this package's dependencies */
+  packageDeps?: string;
 }
 
 export interface ImportMap {

--- a/resolve/local/local.go
+++ b/resolve/local/local.go
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package local
 
 import (
+	"fmt"
 	"maps"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,8 @@ type Resolver struct {
 	includeRootExports bool
 	cache              packagejson.Cache
 	conditions         []string // export condition priority
+	pathBase          string
+	packageDeps        string
 }
 
 // New creates a new local Resolver.
@@ -68,6 +71,8 @@ func (r *Resolver) WithPackages(packages []string) *Resolver {
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -85,6 +90,8 @@ func (r *Resolver) WithExclude(packages []string) *Resolver {
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -105,6 +112,8 @@ func (r *Resolver) WithTemplate(pattern string) (*Resolver, error) {
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}, nil
 }
 
@@ -122,6 +131,8 @@ func (r *Resolver) WithInputMap(im *importmap.ImportMap) *Resolver {
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -140,6 +151,8 @@ func (r *Resolver) WithWorkspacePackages(packages []resolve.WorkspacePackage) *R
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -158,6 +171,8 @@ func (r *Resolver) WithIncludeRootExports() *Resolver {
 		includeRootExports: true,
 		cache:              r.cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -177,6 +192,8 @@ func (r *Resolver) WithPackageCache(cache packagejson.Cache) *Resolver {
 		includeRootExports: r.includeRootExports,
 		cache:              cache,
 		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
 }
 
@@ -195,7 +212,69 @@ func (r *Resolver) WithConditions(conditions []string) *Resolver {
 		includeRootExports: r.includeRootExports,
 		cache:              r.cache,
 		conditions:         conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        r.packageDeps,
 	}
+}
+
+// WithPathBase returns a new Resolver that rebases workspace package paths
+// relative to the given directory instead of the resolution root.
+// Paths under node_modules are not affected.
+// Use this when resolving from a workspace root on behalf of a subdirectory
+// package, so that the subdirectory's own exports map to "/" rather than
+// their full workspace-relative path.
+func (r *Resolver) WithPathBase(dir string) *Resolver {
+	return &Resolver{
+		fs:                 r.fs,
+		logger:             r.logger,
+		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
+		template:           r.template,
+		inputMap:           r.inputMap,
+		workspacePackages:  r.workspacePackages,
+		includeRootExports: r.includeRootExports,
+		cache:              r.cache,
+		conditions:         r.conditions,
+		pathBase:          dir,
+		packageDeps:        r.packageDeps,
+	}
+}
+
+// WithPackageDeps returns a new Resolver that limits dependency collection
+// to only dependencies listed in the package.json at the given directory.
+// Without this, workspace resolution collects dependencies from every
+// workspace package, which may produce warnings for irrelevant packages.
+func (r *Resolver) WithPackageDeps(dir string) *Resolver {
+	return &Resolver{
+		fs:                 r.fs,
+		logger:             r.logger,
+		additionalPackages: r.additionalPackages,
+		excludePackages:    r.excludePackages,
+		template:           r.template,
+		inputMap:           r.inputMap,
+		workspacePackages:  r.workspacePackages,
+		includeRootExports: r.includeRootExports,
+		cache:              r.cache,
+		conditions:         r.conditions,
+		pathBase:          r.pathBase,
+		packageDeps:        dir,
+	}
+}
+
+// normalizePathOptions returns a new Resolver with pathBase and packageDeps
+// resolved to absolute paths relative to rootDir.
+func (r *Resolver) normalizePathOptions(rootDir string) *Resolver {
+	if r.pathBase == "" && r.packageDeps == "" {
+		return r
+	}
+	normalized := *r
+	if normalized.pathBase != "" && !filepath.IsAbs(normalized.pathBase) {
+		normalized.pathBase = filepath.Join(rootDir, normalized.pathBase)
+	}
+	if normalized.packageDeps != "" && !filepath.IsAbs(normalized.packageDeps) {
+		normalized.packageDeps = filepath.Join(rootDir, normalized.packageDeps)
+	}
+	return &normalized
 }
 
 // resolveOpts returns ResolveOptions for the configured conditions.
@@ -352,6 +431,8 @@ func (r *Resolver) resolveInternal(rootDir string, graph *resolve.DependencyGrap
 	}
 	rootDir = absRoot
 
+	r = r.normalizePathOptions(rootDir)
+
 	// Use workspace mode if workspace packages are explicitly configured
 	if len(r.workspacePackages) > 0 {
 		return r.resolveWorkspaceInternal(rootDir, graph)
@@ -487,18 +568,44 @@ func (r *Resolver) resolveWorkspaceInternal(rootDir string, graph *resolve.Depen
 		}
 	}
 
-	// 2. Collect dependencies from all workspace packages (excluding other workspace packages)
+	// 2. Collect dependencies (excluding other workspace packages)
 	allDeps := make(map[string]bool)
-	for _, pkg := range r.workspacePackages {
-		pkgJSON, err := r.parsePackageJSON(filepath.Join(pkg.Path, "package.json"))
+	if r.packageDeps != "" {
+		pkgJSON, err := r.parsePackageJSON(filepath.Join(r.packageDeps, "package.json"))
 		if err != nil {
-			continue
+			return nil, graph, fmt.Errorf("package-deps %s: %w", r.packageDeps, err)
 		}
-		for depName := range pkgJSON.Dependencies {
-			if !workspaceNames[depName] {
-				allDeps[depName] = true
-				if graph != nil {
-					graph.AddDependency(pkg.Name, depName)
+		{
+			var ownerName string
+			if graph != nil {
+				for _, pkg := range r.workspacePackages {
+					if pkg.Path == r.packageDeps {
+						ownerName = pkg.Name
+						break
+					}
+				}
+			}
+			for depName := range pkgJSON.Dependencies {
+				if !workspaceNames[depName] {
+					allDeps[depName] = true
+					if graph != nil && ownerName != "" {
+						graph.AddDependency(ownerName, depName)
+					}
+				}
+			}
+		}
+	} else {
+		for _, pkg := range r.workspacePackages {
+			pkgJSON, err := r.parsePackageJSON(filepath.Join(pkg.Path, "package.json"))
+			if err != nil {
+				continue
+			}
+			for depName := range pkgJSON.Dependencies {
+				if !workspaceNames[depName] {
+					allDeps[depName] = true
+					if graph != nil {
+						graph.AddDependency(pkg.Name, depName)
+					}
 				}
 			}
 		}
@@ -565,7 +672,10 @@ func (r *Resolver) resolveWorkspaceInternal(rootDir string, graph *resolve.Depen
 		result.Scopes = nil
 	}
 
-	// 5. Merge with input map if provided (input map takes precedence)
+	// 5. Rebase paths for serve root
+	r.rebaseImportMapForPathBase(result, rootDir)
+
+	// 6. Merge with input map if provided (input map takes precedence)
 	if r.inputMap != nil {
 		result = result.Merge(r.inputMap)
 	}
@@ -823,6 +933,8 @@ func (r *Resolver) ResolveIncremental(rootDir string, update resolve.Incremental
 	}
 	rootDir = absRoot
 
+	r = r.normalizePathOptions(rootDir)
+
 	// Invalidate cache for changed packages
 	if r.cache != nil {
 		for _, pkgName := range update.ChangedPackages {
@@ -866,7 +978,10 @@ func (r *Resolver) ResolveIncremental(rootDir string, update resolve.Incremental
 					pkg := resolve.WorkspacePackage{Name: name, Path: pkgPath}
 					newGraph.AddWorkspacePackage(name)
 					newGraph.SetPackagePath(name, pkgPath)
-					if err := r.addWorkspacePackageToImportMapWithGraph(result, pkg, rootDir, newGraph); err != nil {
+					mu.Lock()
+					err := r.addWorkspacePackageToImportMapWithGraph(result, pkg, rootDir, newGraph)
+					mu.Unlock()
+					if err != nil {
 						if r.logger != nil {
 							r.logger.Warning("Failed to re-add workspace package %s: %v", name, err)
 						}
@@ -923,6 +1038,9 @@ func (r *Resolver) ResolveIncremental(rootDir string, update resolve.Incremental
 		result.Scopes = nil
 	}
 
+	// Rebase paths for serve root
+	r.rebaseImportMapForPathBase(result, rootDir)
+
 	// Merge with input map if provided (input map takes precedence)
 	if r.inputMap != nil {
 		result = result.Merge(r.inputMap)
@@ -974,4 +1092,42 @@ func (r *Resolver) removePackageFromMap(im *importmap.ImportMap, pkgName string,
 	if scopeKey != "" && im.Scopes != nil {
 		delete(im.Scopes, scopeKey)
 	}
+}
+
+func (r *Resolver) rebaseImportMapForPathBase(im *importmap.ImportMap, rootDir string) {
+	if r.pathBase == "" {
+		return
+	}
+	relPath, err := filepath.Rel(rootDir, r.pathBase)
+	if err != nil || relPath == "." || strings.HasPrefix(relPath, "..") {
+		return
+	}
+	prefix := "/" + filepath.ToSlash(relPath)
+
+	for key, value := range im.Imports {
+		im.Imports[key] = rebasePath(value, prefix)
+	}
+
+	if im.Scopes != nil {
+		newScopes := make(map[string]map[string]string, len(im.Scopes))
+		for scopeKey, scopeMap := range im.Scopes {
+			newKey := rebasePath(scopeKey, prefix)
+			newMap := make(map[string]string, len(scopeMap))
+			for k, v := range scopeMap {
+				newMap[k] = rebasePath(v, prefix)
+			}
+			newScopes[newKey] = newMap
+		}
+		im.Scopes = newScopes
+	}
+}
+
+func rebasePath(path, prefix string) string {
+	if path == prefix {
+		return "/"
+	}
+	if after, ok := strings.CutPrefix(path, prefix+"/"); ok {
+		return "/" + after
+	}
+	return path
 }

--- a/resolve/local/local.go
+++ b/resolve/local/local.go
@@ -575,22 +575,20 @@ func (r *Resolver) resolveWorkspaceInternal(rootDir string, graph *resolve.Depen
 		if err != nil {
 			return nil, graph, fmt.Errorf("package-deps %s: %w", r.packageDeps, err)
 		}
-		{
-			var ownerName string
-			if graph != nil {
-				for _, pkg := range r.workspacePackages {
-					if pkg.Path == r.packageDeps {
-						ownerName = pkg.Name
-						break
-					}
+		var ownerName string
+		if graph != nil {
+			for _, pkg := range r.workspacePackages {
+				if pkg.Path == r.packageDeps {
+					ownerName = pkg.Name
+					break
 				}
 			}
-			for depName := range pkgJSON.Dependencies {
-				if !workspaceNames[depName] {
-					allDeps[depName] = true
-					if graph != nil && ownerName != "" {
-						graph.AddDependency(ownerName, depName)
-					}
+		}
+		for depName := range pkgJSON.Dependencies {
+			if !workspaceNames[depName] {
+				allDeps[depName] = true
+				if graph != nil && ownerName != "" {
+					graph.AddDependency(ownerName, depName)
 				}
 			}
 		}

--- a/resolve/local/local_test.go
+++ b/resolve/local/local_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 
@@ -371,5 +372,356 @@ func TestResolverExplicitWorkspacesOverrideAutoDiscovery(t *testing.T) {
 	// Should NOT have the auto-discovered package (since explicit was provided)
 	if _, ok := result.Imports["@myorg/components"]; ok {
 		t.Error("Expected @myorg/components to not be auto-discovered when explicit packages provided")
+	}
+}
+
+func TestResolverWithPathBase(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	expectedData, err := mfs.ReadFile("/test/expected.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected.json: %v", err)
+	}
+
+	var expected importmap.ImportMap
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to parse expected.json: %v", err)
+	}
+
+	resolver := local.New(mfs, nil).WithPathBase("/test/examples/kitchen-sink")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Imports, expected.Imports) {
+		t.Errorf("Imports mismatch:\n  got:      %v\n  expected: %v", result.Imports, expected.Imports)
+	}
+
+	// Workspace package at serve root should be rebased to /
+	if result.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("Expected @examples/kitchen-sink/ to be rebased to /, got %s",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+
+	// node_modules paths should be unchanged
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Expected lit path unchanged, got %s", result.Imports["lit"])
+	}
+
+	// Scope keys under node_modules should NOT be rebased
+	if !reflect.DeepEqual(result.Scopes, expected.Scopes) {
+		t.Errorf("Scopes mismatch:\n  got:      %v\n  expected: %v", result.Scopes, expected.Scopes)
+	}
+}
+
+func TestResolverWithPathBaseSameAsRoot(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	expectedData, err := mfs.ReadFile("/test/expected-no-rebase.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected-no-rebase.json: %v", err)
+	}
+
+	var expected importmap.ImportMap
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to parse expected-no-rebase.json: %v", err)
+	}
+
+	// Serve root == resolution root: no rebasing
+	resolver := local.New(mfs, nil).WithPathBase("/test")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Imports, expected.Imports) {
+		t.Errorf("Imports mismatch:\n  got:      %v\n  expected: %v", result.Imports, expected.Imports)
+	}
+}
+
+func TestResolverWithPathBaseAutoDiscovery(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	// No explicit WithWorkspacePackages -- auto-discover + serve root
+	resolver := local.New(mfs, nil).WithPathBase("/test/examples/kitchen-sink")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if result.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("Expected @examples/kitchen-sink/ to be rebased to /, got %s",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+
+	if result.Imports["@examples/kitchen-sink"] != "/src/index.js" {
+		t.Errorf("Expected @examples/kitchen-sink to be /src/index.js, got %s",
+			result.Imports["@examples/kitchen-sink"])
+	}
+
+	// Other workspace package paths should NOT be rebased
+	if result.Imports["@myorg/lib"] != "/packages/lib/src/index.js" {
+		t.Errorf("Expected @myorg/lib to remain /packages/lib/src/index.js, got %s",
+			result.Imports["@myorg/lib"])
+	}
+}
+
+func TestResolverWithPackageDeps(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-package-deps", "/test")
+
+	expectedData, err := mfs.ReadFile("/test/expected-core-deps.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected-core-deps.json: %v", err)
+	}
+
+	var expected importmap.ImportMap
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to parse expected-core-deps.json: %v", err)
+	}
+
+	resolver := local.New(mfs, nil).WithPackageDeps("/test/packages/core")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Imports, expected.Imports) {
+		t.Errorf("Imports mismatch:\n  got:      %v\n  expected: %v", result.Imports, expected.Imports)
+	}
+
+	// lit should be present (core dep)
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Expected lit import, got %s", result.Imports["lit"])
+	}
+
+	// lodash should NOT be present (tools dep, not core)
+	if _, ok := result.Imports["lodash"]; ok {
+		t.Error("Expected lodash to be excluded (not a dep of core)")
+	}
+
+	// Both workspace packages should still appear in imports
+	if result.Imports["@myorg/core"] != "/packages/core/src/index.js" {
+		t.Errorf("Expected @myorg/core workspace package, got %s", result.Imports["@myorg/core"])
+	}
+	if result.Imports["@myorg/tools"] != "/packages/tools/src/index.js" {
+		t.Errorf("Expected @myorg/tools workspace package, got %s", result.Imports["@myorg/tools"])
+	}
+}
+
+func TestResolverWithPackageDepsFallback(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-package-deps", "/test")
+
+	expectedData, err := mfs.ReadFile("/test/expected-all-deps.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected-all-deps.json: %v", err)
+	}
+
+	var expected importmap.ImportMap
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to parse expected-all-deps.json: %v", err)
+	}
+
+	// No WithPackageDeps: all deps from all workspace packages
+	resolver := local.New(mfs, nil)
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Imports, expected.Imports) {
+		t.Errorf("Imports mismatch:\n  got:      %v\n  expected: %v", result.Imports, expected.Imports)
+	}
+}
+
+func TestResolverWithPackageDepsError(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-package-deps", "/test")
+
+	resolver := local.New(mfs, nil).WithPackageDeps("/test/nonexistent")
+	_, err := resolver.Resolve("/test")
+	if err == nil {
+		t.Fatal("Expected error for nonexistent packageDeps path")
+	}
+	if !strings.Contains(err.Error(), "package-deps") {
+		t.Errorf("Expected error to mention package-deps, got: %v", err)
+	}
+}
+
+func TestResolverWithPathBaseAndPackageDeps(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-package-deps", "/test")
+
+	resolver := local.New(mfs, nil).
+		WithPathBase("/test/packages/core").
+		WithPackageDeps("/test/packages/core")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	// core's path should be rebased
+	if result.Imports["@myorg/core"] != "/src/index.js" {
+		t.Errorf("Expected @myorg/core rebased to /src/index.js, got %s",
+			result.Imports["@myorg/core"])
+	}
+
+	// lit should be present (core dep)
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Expected lit import, got %s", result.Imports["lit"])
+	}
+
+	// lodash should NOT be present
+	if _, ok := result.Imports["lodash"]; ok {
+		t.Error("Expected lodash excluded")
+	}
+}
+
+func TestResolverBuilderPropagation(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	cache := packagejson.NewMemoryCache()
+
+	// Chain multiple builders to verify fields propagate
+	resolver := local.New(mfs, nil).
+		WithPathBase("/test/examples/kitchen-sink").
+		WithPackageDeps("/test/examples/kitchen-sink").
+		WithPackageCache(cache).
+		WithConditions([]string{"browser", "import", "default"}).
+		WithExclude([]string{"nonexistent-pkg"}).
+		WithPackages([]string{}).
+		WithIncludeRootExports()
+
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	// PathBase should have survived the builder chain
+	if result.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("PathBase lost in builder chain: @examples/kitchen-sink/ = %s, want /",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+
+	// PackageDeps should have survived: only kitchen-sink's dep (lit) should appear
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("PackageDeps lost in builder chain: lit = %s", result.Imports["lit"])
+	}
+}
+
+func TestOptionsApplyPathBaseAndPackageDeps(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	opts := &local.Options{
+		PathBase:   "/test/examples/kitchen-sink",
+		PackageDeps: "/test/examples/kitchen-sink",
+	}
+
+	resolver, err := opts.Apply(local.New(mfs, nil))
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if result.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("PathBase not applied via Options: @examples/kitchen-sink/ = %s, want /",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+}
+
+func TestResolverWithPathBaseOutsideRoot(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	// pathBase outside rootDir -- should be a no-op
+	resolver := local.New(mfs, nil).WithPathBase("/other")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	// paths should not be rebased
+	if result.Imports["@examples/kitchen-sink/"] != "/examples/kitchen-sink/" {
+		t.Errorf("Expected no rebasing, got @examples/kitchen-sink/ = %s",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+}
+
+func TestResolverWithRelativePathBase(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	// Relative pathBase should be resolved relative to rootDir
+	resolver := local.New(mfs, nil).WithPathBase("examples/kitchen-sink")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if result.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("Relative pathBase not normalized: @examples/kitchen-sink/ = %s, want /",
+			result.Imports["@examples/kitchen-sink/"])
+	}
+}
+
+func TestResolverWithRelativePackageDeps(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-package-deps", "/test")
+
+	// Relative packageDeps should be resolved relative to rootDir
+	resolver := local.New(mfs, nil).WithPackageDeps("packages/core")
+	result, err := resolver.Resolve("/test")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	// lit should be present (core dep), lodash should not
+	if result.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Expected lit import with relative packageDeps, got %s", result.Imports["lit"])
+	}
+	if _, ok := result.Imports["lodash"]; ok {
+		t.Error("Expected lodash excluded with relative packageDeps")
+	}
+}
+
+func TestResolverWithPathBaseIncrementalIdempotent(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "workspace-serve-root", "/test")
+
+	workspacePackages := []resolve.WorkspacePackage{
+		{Name: "@examples/kitchen-sink", Path: "/test/examples/kitchen-sink"},
+		{Name: "@myorg/lib", Path: "/test/packages/lib"},
+	}
+
+	resolver := local.New(mfs, nil).
+		WithWorkspacePackages(workspacePackages).
+		WithPathBase("/test/examples/kitchen-sink")
+
+	// Initial resolve with graph
+	initial, err := resolver.ResolveWithGraph("/test")
+	if err != nil {
+		t.Fatalf("ResolveWithGraph failed: %v", err)
+	}
+
+	if initial.ImportMap.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Fatalf("Initial rebase failed: @examples/kitchen-sink/ = %s",
+			initial.ImportMap.Imports["@examples/kitchen-sink/"])
+	}
+
+	// Incremental update -- simulate lit changing
+	incremental, err := resolver.ResolveIncremental("/test", resolve.IncrementalUpdate{
+		ChangedPackages: []string{"lit"},
+		PreviousMap:     initial.ImportMap,
+		PreviousGraph:   initial.DependencyGraph,
+	})
+	if err != nil {
+		t.Fatalf("ResolveIncremental failed: %v", err)
+	}
+
+	// Rebase should still be correct (idempotent on cloned entries)
+	if incremental.ImportMap.Imports["@examples/kitchen-sink/"] != "/" {
+		t.Errorf("Incremental rebase wrong: @examples/kitchen-sink/ = %s, want /",
+			incremental.ImportMap.Imports["@examples/kitchen-sink/"])
+	}
+	if incremental.ImportMap.Imports["lit"] != "/node_modules/lit/index.js" {
+		t.Errorf("Incremental lit wrong: %s", incremental.ImportMap.Imports["lit"])
 	}
 }

--- a/resolve/local/options.go
+++ b/resolve/local/options.go
@@ -30,6 +30,8 @@ type Options struct {
 	IncludePackages []string
 	Exclude         []string
 	InputMap        *importmap.ImportMap
+	PathBase    string
+	PackageDeps     string
 }
 
 // Apply configures the given Resolver with these options, returning the result.
@@ -55,6 +57,12 @@ func (o *Options) Apply(r *Resolver) (*Resolver, error) {
 	}
 	if o.InputMap != nil {
 		r = r.WithInputMap(o.InputMap)
+	}
+	if o.PathBase != "" {
+		r = r.WithPathBase(o.PathBase)
+	}
+	if o.PackageDeps != "" {
+		r = r.WithPackageDeps(o.PackageDeps)
 	}
 	return r, nil
 }

--- a/testdata/workspace-package-deps/expected-all-deps.json
+++ b/testdata/workspace-package-deps/expected-all-deps.json
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "@myorg/core": "/packages/core/src/index.js",
+    "@myorg/tools": "/packages/tools/src/index.js",
+    "lit": "/node_modules/lit/index.js",
+    "lodash": "/node_modules/lodash/lodash.js"
+  }
+}

--- a/testdata/workspace-package-deps/expected-core-deps.json
+++ b/testdata/workspace-package-deps/expected-core-deps.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@myorg/core": "/packages/core/src/index.js",
+    "@myorg/tools": "/packages/tools/src/index.js",
+    "lit": "/node_modules/lit/index.js"
+  }
+}

--- a/testdata/workspace-package-deps/node_modules/lit/package.json
+++ b/testdata/workspace-package-deps/node_modules/lit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lit",
+  "version": "3.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/testdata/workspace-package-deps/node_modules/lodash/package.json
+++ b/testdata/workspace-package-deps/node_modules/lodash/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lodash",
+  "version": "4.17.21",
+  "type": "module",
+  "exports": {
+    ".": "./lodash.js"
+  }
+}

--- a/testdata/workspace-package-deps/package.json
+++ b/testdata/workspace-package-deps/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-root",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/testdata/workspace-package-deps/packages/core/package.json
+++ b/testdata/workspace-package-deps/packages/core/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@myorg/core",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "lit": "^3.0.0"
+  }
+}

--- a/testdata/workspace-package-deps/packages/tools/package.json
+++ b/testdata/workspace-package-deps/packages/tools/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@myorg/tools",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "lodash": "^4.0.0"
+  }
+}

--- a/testdata/workspace-serve-root/examples/kitchen-sink/package.json
+++ b/testdata/workspace-serve-root/examples/kitchen-sink/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@examples/kitchen-sink",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js",
+    "./*": "./*"
+  },
+  "dependencies": {
+    "lit": "^3.0.0"
+  }
+}

--- a/testdata/workspace-serve-root/expected-no-rebase.json
+++ b/testdata/workspace-serve-root/expected-no-rebase.json
@@ -1,0 +1,14 @@
+{
+  "imports": {
+    "@examples/kitchen-sink": "/examples/kitchen-sink/src/index.js",
+    "@examples/kitchen-sink/": "/examples/kitchen-sink/",
+    "@myorg/lib": "/packages/lib/src/index.js",
+    "lit": "/node_modules/lit/index.js",
+    "lit/decorators.js": "/node_modules/lit/decorators.js"
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js"
+    }
+  }
+}

--- a/testdata/workspace-serve-root/expected.json
+++ b/testdata/workspace-serve-root/expected.json
@@ -1,0 +1,14 @@
+{
+  "imports": {
+    "@examples/kitchen-sink": "/src/index.js",
+    "@examples/kitchen-sink/": "/",
+    "@myorg/lib": "/packages/lib/src/index.js",
+    "lit": "/node_modules/lit/index.js",
+    "lit/decorators.js": "/node_modules/lit/decorators.js"
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js"
+    }
+  }
+}

--- a/testdata/workspace-serve-root/node_modules/@lit/reactive-element/package.json
+++ b/testdata/workspace-serve-root/node_modules/@lit/reactive-element/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lit/reactive-element",
+  "version": "2.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./reactive-element.js"
+  }
+}

--- a/testdata/workspace-serve-root/node_modules/lit/package.json
+++ b/testdata/workspace-serve-root/node_modules/lit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lit",
+  "version": "3.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./decorators.js": "./decorators.js"
+  },
+  "dependencies": {
+    "@lit/reactive-element": "^2.0.0"
+  }
+}

--- a/testdata/workspace-serve-root/package.json
+++ b/testdata/workspace-serve-root/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-root",
+  "private": true,
+  "workspaces": ["examples/*", "packages/*"]
+}

--- a/testdata/workspace-serve-root/packages/lib/package.json
+++ b/testdata/workspace-serve-root/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@myorg/lib",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -232,6 +232,8 @@ type resolveOptions struct {
 	exclude         []string
 	inputMap        *importmap.ImportMap
 	optimize        int
+	pathBase         string
+	packageDeps     string
 }
 
 func (o *resolveOptions) localOptions() *local.Options {
@@ -241,6 +243,8 @@ func (o *resolveOptions) localOptions() *local.Options {
 		IncludePackages: o.includePackages,
 		Exclude:         o.exclude,
 		InputMap:        o.inputMap,
+		PathBase:         o.pathBase,
+		PackageDeps:     o.packageDeps,
 	}
 }
 
@@ -274,6 +278,12 @@ func parseResolveOptions(args []js.Value) (resolveOptions, error) {
 	}
 	if v := obj.Get("optimize"); !v.IsUndefined() && !v.IsNull() {
 		opts.optimize = v.Int()
+	}
+	if v := obj.Get("pathBase"); !v.IsUndefined() && !v.IsNull() {
+		opts.pathBase = v.String()
+	}
+	if v := obj.Get("packageDeps"); !v.IsUndefined() && !v.IsNull() {
+		opts.packageDeps = v.String()
 	}
 
 	return opts, nil


### PR DESCRIPTION
## Summary

Closes #38.

- Add `WithPathBase(dir)` option to rebase workspace package paths relative to a given directory instead of the resolution root. Paths under `node_modules/` are unaffected. This moves the `rebaseForServeRoot` workaround from cem into mappa.
- Add `WithPackageDeps(dir)` option to limit dependency collection to only the dependencies listed in the `package.json` at the given directory, avoiding warnings for irrelevant workspace packages.
- Both options are exposed via Go builder methods, CLI flags (`--path-base`, `--package-deps`), WASM/JS options, and the `Options` struct.
- Relative paths for both options are normalized to absolute paths relative to `rootDir`.
- Fix a pre-existing race condition in `ResolveIncremental` where workspace package writes were unprotected by the mutex.

## Test plan

- [x] `TestResolverWithPathBase` -- workspace paths rebased, `node_modules` unchanged, scope keys preserved
- [x] `TestResolverWithPathBaseSameAsRoot` -- no-op when path base equals resolution root
- [x] `TestResolverWithPathBaseAutoDiscovery` -- works with auto-discovered workspaces
- [x] `TestResolverWithPathBaseOutsideRoot` -- no-op when path base is outside root
- [x] `TestResolverWithRelativePathBase` -- relative path normalized correctly
- [x] `TestResolverWithPathBaseIncrementalIdempotent` -- rebase is idempotent across incremental updates
- [x] `TestResolverWithPackageDeps` -- only scoped package's deps resolved
- [x] `TestResolverWithPackageDepsFallback` -- all deps when `packageDeps` unset
- [x] `TestResolverWithPackageDepsError` -- error returned for nonexistent path
- [x] `TestResolverWithRelativePackageDeps` -- relative path normalized correctly
- [x] `TestResolverWithPathBaseAndPackageDeps` -- combined usage
- [x] `TestResolverBuilderPropagation` -- all fields survive builder method chaining
- [x] `TestOptionsApplyPathBaseAndPackageDeps` -- `Options.Apply` wiring
- [x] 351 tests pass, zero lint issues, zero race conditions

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added path-base configuration option for rebasing workspace paths during import-map generation
  * Added package-deps option to limit dependency resolution to a specific package's dependencies
  * Extended CLI and API interfaces to support both new configuration parameters

* **Tests**
  * Expanded test coverage for path-base rebasing, workspace behavior, and package-scoped dependency resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->