### PR TITLE
fix: emit trailing-slash entries for wildcard exports with target suffixes

### DIFF
--- a/packagejson/packagejson.go
+++ b/packagejson/packagejson.go
@@ -160,11 +160,12 @@ func (pkg *PackageJSON) ImportMapEntries(opts *ResolveOptions) []ImportMapEntry 
 
 	wildcards := pkg.WildcardExports(opts)
 	for _, w := range wildcards {
-		// Only emit folder mappings for pure wildcards (no suffix transform).
-		// Patterns like "./*.js" -> "./src/*.mjs" can't be expressed as
-		// trailing-slash keys since the extension transform would be lost.
+		// Skip patterns with a suffix (e.g., "./*.js" -> "./src/*.mjs")
+		// since the pattern suffix can't be expressed as a trailing-slash key.
+		// Target suffixes are fine: the trailing-slash key maps the prefix,
+		// and the browser carries the rest (including any extension) through.
 		_, patternSuffix, _ := strings.Cut(w.Pattern, "*")
-		if patternSuffix != "" || w.TargetSuffix != "" {
+		if patternSuffix != "" {
 			continue
 		}
 		patternPrefix := strings.TrimSuffix(trimDotSlash(w.Pattern), "*")

--- a/packagejson/packagejson_test.go
+++ b/packagejson/packagejson_test.go
@@ -706,6 +706,53 @@ func TestResolveImport(t *testing.T) {
 	}
 }
 
+func TestImportMapEntriesWildcardSubpath(t *testing.T) {
+	mfs := testutil.NewFixtureFS(t, "packagejson/wildcard-subpath-exports", "/test")
+
+	pkg, err := packagejson.ParseFile(mfs, "/test/package.json")
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	expectedBytes, err := mfs.ReadFile("/test/expected.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected.json: %v", err)
+	}
+
+	var expected struct {
+		Entries []struct {
+			Key  string `json:"key"`
+			Path string `json:"path"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(expectedBytes, &expected); err != nil {
+		t.Fatalf("Failed to parse expected.json: %v", err)
+	}
+
+	entries := pkg.ImportMapEntries(nil)
+
+	// Build lookup for actual entries
+	actual := make(map[string]string)
+	for _, e := range entries {
+		actual[e.Key] = e.Path
+	}
+
+	for _, want := range expected.Entries {
+		got, ok := actual[want.Key]
+		if !ok {
+			t.Errorf("Missing entry for key %q", want.Key)
+			continue
+		}
+		if got != want.Path {
+			t.Errorf("Entry key %q: got path %q, want %q", want.Key, got, want.Path)
+		}
+	}
+
+	if len(entries) != len(expected.Entries) {
+		t.Errorf("Entry count: got %d, want %d\n  actual: %v", len(entries), len(expected.Entries), entries)
+	}
+}
+
 func TestResolveImportNoImportsField(t *testing.T) {
 	pkg := &packagejson.PackageJSON{Name: "test"}
 	_, err := pkg.ResolveImport("#anything", nil)

--- a/resolve/local/local_test.go
+++ b/resolve/local/local_test.go
@@ -60,6 +60,7 @@ func TestResolver(t *testing.T) {
 		{"simple package", "simple-pkg"},
 		{"with scopes", "with-scopes"},
 		{"scope simplification with wildcards", "with-wildcard-scopes"},
+		{"wildcard subpath exports in scopes", "wildcard-subpath-scopes"},
 		{"circular dependencies", "circular-deps"},
 		{"nested node_modules", "nested-node-modules"},
 		{"peer dependencies in scopes", "with-peer-deps"},

--- a/testdata/packagejson/wildcard-subpath-exports/expected.json
+++ b/testdata/packagejson/wildcard-subpath-exports/expected.json
@@ -1,0 +1,6 @@
+{
+  "entries": [
+    {"key": "", "path": "reactive-element.js"},
+    {"key": "/decorators/", "path": "decorators/"}
+  ]
+}

--- a/testdata/packagejson/wildcard-subpath-exports/package.json
+++ b/testdata/packagejson/wildcard-subpath-exports/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "reactive-element",
+  "version": "2.0.0",
+  "exports": {
+    ".": "./reactive-element.js",
+    "./decorators/*": "./decorators/*.js"
+  }
+}

--- a/testdata/resolve/wildcard-subpath-scopes/expected.json
+++ b/testdata/resolve/wildcard-subpath-scopes/expected.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js"
+  },
+  "scopes": {
+    "/node_modules/lit/": {
+      "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+      "@lit/reactive-element/decorators/": "/node_modules/@lit/reactive-element/decorators/"
+    }
+  }
+}

--- a/testdata/resolve/wildcard-subpath-scopes/node_modules/@lit/reactive-element/package.json
+++ b/testdata/resolve/wildcard-subpath-scopes/node_modules/@lit/reactive-element/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lit/reactive-element",
+  "version": "2.0.0",
+  "exports": {
+    ".": "./reactive-element.js",
+    "./decorators/*": "./decorators/*.js"
+  }
+}

--- a/testdata/resolve/wildcard-subpath-scopes/node_modules/lit/package.json
+++ b/testdata/resolve/wildcard-subpath-scopes/node_modules/lit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lit",
+  "version": "3.0.0",
+  "exports": {
+    ".": "./index.js"
+  },
+  "dependencies": {
+    "@lit/reactive-element": "^2.0.0"
+  }
+}

--- a/testdata/resolve/wildcard-subpath-scopes/package.json
+++ b/testdata/resolve/wildcard-subpath-scopes/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "dependencies": {
+    "lit": "^3.0.0"
+  }
+}

--- a/testdata/resolve/with-wildcard-scopes/expected.json
+++ b/testdata/resolve/with-wildcard-scopes/expected.json
@@ -5,6 +5,7 @@
   "scopes": {
     "/node_modules/parent-pkg/": {
       "dep-with-wildcards": "/node_modules/dep-with-wildcards/index.js",
+      "dep-with-wildcards/": "/node_modules/dep-with-wildcards/dist/",
       "dep-with-wildcards/button": "/node_modules/dep-with-wildcards/dist/button.js"
     }
   }


### PR DESCRIPTION
## Summary

- Wildcard subpath pattern exports like `./decorators/*` -> `./decorators/*.js` were not generating trailing-slash import map entries
- Root cause: `ImportMapEntries` incorrectly skipped wildcards when `TargetSuffix` was non-empty
- Only *pattern* suffixes (e.g., `./*.js`) prevent trailing-slash keys; target suffixes are carried through by the browser's prefix replacement

Fixes #40

## Test plan

- [x] `TestImportMapEntriesWildcardSubpath` verifies trailing-slash entry for `./decorators/*` -> `./decorators/*.js`
- [x] `TestResolver/wildcard_subpath_exports_in_scopes` verifies scope entries with lit + @lit/reactive-element reproduction
- [x] Updated `with-wildcard-scopes` golden file reflects new `dep-with-wildcards/` entry
- [x] `make lint` and `make test` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of wildcard exports in package configuration to properly support wildcard subpath patterns without dependency on suffix logic.

* **Tests**
  * Added comprehensive test coverage for wildcard subpath export scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->