### PR TITLE
fix: preserve trailing slashes in nested dep URLs

### DIFF
--- a/resolve/local/local.go
+++ b/resolve/local/local.go
@@ -907,7 +907,11 @@ func (r *Resolver) expandDepURL(depName, filePath string, nested bool, depPath, 
 	if err != nil {
 		return r.template.Expand(depName, "", filePath)
 	}
-	return "/" + filepath.ToSlash(rel)
+	result := "/" + filepath.ToSlash(rel)
+	if strings.HasSuffix(filePath, "/") || filePath == "" {
+		result += "/"
+	}
+	return result
 }
 
 // parsePackageName extracts the package name from a package spec.

--- a/resolve/local/local_test.go
+++ b/resolve/local/local_test.go
@@ -64,6 +64,8 @@ func TestResolver(t *testing.T) {
 		{"circular dependencies", "circular-deps"},
 		{"nested node_modules", "nested-node-modules"},
 		{"peer dependencies in scopes", "with-peer-deps"},
+		{"nested dep trailing-slash exports", "nested-trailing-slash"},
+		{"mixed nested and hoisted with wildcards", "nested-mixed-hoisted"},
 	}
 
 	for _, tt := range tests {

--- a/testdata/resolve/nested-mixed-hoisted/expected.json
+++ b/testdata/resolve/nested-mixed-hoisted/expected.json
@@ -1,0 +1,18 @@
+{
+  "imports": {
+    "alpha": "/node_modules/alpha/index.js",
+    "beta": "/node_modules/beta/index.js",
+    "shared-lib": "/node_modules/shared-lib/index.js",
+    "shared-lib/": "/node_modules/shared-lib/src/"
+  },
+  "scopes": {
+    "/node_modules/alpha/": {
+      "shared-lib": "/node_modules/alpha/node_modules/shared-lib/v1.js",
+      "shared-lib/": "/node_modules/alpha/node_modules/shared-lib/lib/"
+    },
+    "/node_modules/beta/": {
+      "shared-lib": "/node_modules/shared-lib/index.js",
+      "shared-lib/": "/node_modules/shared-lib/src/"
+    }
+  }
+}

--- a/testdata/resolve/nested-mixed-hoisted/node_modules/alpha/node_modules/shared-lib/package.json
+++ b/testdata/resolve/nested-mixed-hoisted/node_modules/alpha/node_modules/shared-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-lib",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./v1.js",
+    "./*": "./lib/*.js"
+  }
+}

--- a/testdata/resolve/nested-mixed-hoisted/node_modules/alpha/package.json
+++ b/testdata/resolve/nested-mixed-hoisted/node_modules/alpha/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "alpha",
+  "version": "1.0.0",
+  "exports": { ".": "./index.js" },
+  "dependencies": { "shared-lib": "^1.0.0" }
+}

--- a/testdata/resolve/nested-mixed-hoisted/node_modules/beta/package.json
+++ b/testdata/resolve/nested-mixed-hoisted/node_modules/beta/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "beta",
+  "version": "1.0.0",
+  "exports": { ".": "./index.js" },
+  "dependencies": { "shared-lib": "^2.0.0" }
+}

--- a/testdata/resolve/nested-mixed-hoisted/node_modules/shared-lib/package.json
+++ b/testdata/resolve/nested-mixed-hoisted/node_modules/shared-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-lib",
+  "version": "2.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./src/*.js"
+  }
+}

--- a/testdata/resolve/nested-mixed-hoisted/package.json
+++ b/testdata/resolve/nested-mixed-hoisted/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-test",
+  "dependencies": {
+    "alpha": "^1.0.0",
+    "beta": "^1.0.0",
+    "shared-lib": "^2.0.0"
+  }
+}

--- a/testdata/resolve/nested-trailing-slash/expected.json
+++ b/testdata/resolve/nested-trailing-slash/expected.json
@@ -1,0 +1,14 @@
+{
+  "imports": {
+    "parent-pkg": "/node_modules/parent-pkg/index.js"
+  },
+  "scopes": {
+    "/node_modules/parent-pkg/": {
+      "@nested/lib": "/node_modules/parent-pkg/node_modules/@nested/lib/index.js",
+      "@nested/lib/": "/node_modules/parent-pkg/node_modules/@nested/lib/src/",
+      "@nested/lib/controllers/": "/node_modules/parent-pkg/node_modules/@nested/lib/controllers/",
+      "no-exports-dep": "/node_modules/parent-pkg/node_modules/no-exports-dep/index.js",
+      "no-exports-dep/": "/node_modules/parent-pkg/node_modules/no-exports-dep/"
+    }
+  }
+}

--- a/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/node_modules/@nested/lib/package.json
+++ b/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/node_modules/@nested/lib/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@nested/lib",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./src/*.js",
+    "./controllers/*": "./controllers/*.js"
+  }
+}

--- a/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/node_modules/no-exports-dep/package.json
+++ b/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/node_modules/no-exports-dep/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-exports-dep",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/package.json
+++ b/testdata/resolve/nested-trailing-slash/node_modules/parent-pkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "parent-pkg",
+  "version": "1.0.0",
+  "exports": { ".": "./index.js" },
+  "dependencies": { "@nested/lib": "^1.0.0", "no-exports-dep": "^1.0.0" }
+}

--- a/testdata/resolve/nested-trailing-slash/package.json
+++ b/testdata/resolve/nested-trailing-slash/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nested-trailing-slash-test",
+  "dependencies": {
+    "parent-pkg": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- Fix `expandDepURL` to re-append trailing slashes that `filepath.Join` strips from nested dependency URLs
- Add test fixture for nested dep with wildcard exports, scoped packages, and main-only fallback
- Add test fixture for mixed nested+hoisted scenario verifying hoisted deps are unaffected

Closes #42

## Details

`filepath.Join(depPath, filePath)` strips trailing slashes. When `filePath` is `""` (plain trailing-slash fallback) or ends with `/` (wildcard export target prefix like `src/`), the generated import map address loses its trailing slash. Hoisted deps were unaffected because they use `template.Expand`, which preserves the slash from the template pattern.

The fix checks the original `filePath` parameter after computing the relative path and re-appends the slash when needed.

## Test plan

- [x] New `nested-trailing-slash` fixture: scoped nested dep (`@nested/lib`) with wildcard exports (`./*`, `./controllers/*`) and a main-only dep (`no-exports-dep`) with empty filePath fallback
- [x] New `nested-mixed-hoisted` fixture: same `shared-lib` dep nested under `alpha` (v1) and hoisted for `beta` (v2), verifying trailing slashes on both paths
- [x] Verified fix reverted causes both new tests to fail (red-green confirmed)
- [x] All 355 existing tests pass, zero lint issues (`make lint && make test`)

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested dependency URL expansion to correctly handle trailing slashes for directory-like paths.

* **Tests**
  * Added test cases for nested dependency resolution with trailing slashes and mixed hoisted scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->